### PR TITLE
Eliminated a warning in WebSocketHandler

### DIFF
--- a/Sources/WebSocket/WebSocketHandler.swift
+++ b/Sources/WebSocket/WebSocketHandler.swift
@@ -34,7 +34,7 @@ private final class WebSocketHandler: ChannelInboundHandler {
 
     /// See `ChannelInboundHandler`.
     func channelRead(ctx: ChannelHandlerContext, data: NIOAny) {
-        var frame = self.unwrapInboundIn(data)
+        let frame = self.unwrapInboundIn(data)
         switch frame.opcode {
         case .connectionClose: receivedClose(ctx: ctx, frame: frame)
         case .ping:


### PR DESCRIPTION
The waring says: "Variable 'frame' was never mutated; consider changing to 'let' constant".
Changed it from `var` to `let`.
