### PR TITLE
Add errorCaught handler to close the WebSocket.

### DIFF
--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -55,7 +55,7 @@ private final class WebSocketHandler: ChannelInboundHandler {
         self.webSocket.handle(incoming: frame)
     }
 
-    public func errorCaught(context: ChannelHandlerContext, error: Error) {
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
         let errorCode: WebSocketErrorCode
         if let error = error as? NIOWebSocketError {
             errorCode = WebSocketErrorCode(error)

--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -28,6 +28,18 @@ extension WebSocket {
     }
 }
 
+extension WebSocketErrorCode {
+    init(_ error: NIOWebSocketError) {
+        switch error {
+        case .invalidFrameLength:
+            self = .messageTooLarge
+        case .fragmentedControlFrame,
+             .multiByteControlFrameLength:
+            self = .protocolError
+        }
+    }
+}
+
 private final class WebSocketHandler: ChannelInboundHandler {
     typealias InboundIn = WebSocketFrame
     typealias OutboundOut = WebSocketFrame
@@ -41,5 +53,18 @@ private final class WebSocketHandler: ChannelInboundHandler {
     func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let frame = self.unwrapInboundIn(data)
         self.webSocket.handle(incoming: frame)
+    }
+
+    public func errorCaught(context: ChannelHandlerContext, error: Error) {
+        let errorCode: WebSocketErrorCode
+        if let error = error as? NIOWebSocketError {
+            errorCode = WebSocketErrorCode(error)
+        } else {
+            errorCode = .unexpectedServerError
+        }
+        _ = webSocket.close(code: errorCode)
+
+        // We always forward the error on to let others see it.
+        context.fireErrorCaught(error)
     }
 }


### PR DESCRIPTION
This addresses https://github.com/vapor/websocket-kit/issues/58. Now when an error is thrown by NIO we receive it and close the WebSocket connection. The error code is available on WebSocket.closeCode by the time the WebSocket.onClose future resolves.