### PR TITLE
Add channelInactive callback to mark WebSocket as closed.

### DIFF
--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -42,4 +42,12 @@ private final class WebSocketHandler: ChannelInboundHandler {
         let frame = self.unwrapInboundIn(data)
         self.webSocket.handle(incoming: frame)
     }
+
+    func channelInactive(context: ChannelHandlerContext) {
+        let closedAbnormally = WebSocketErrorCode.unknown(1005)
+        _ = webSocket.close(code: closedAbnormally)
+
+        // We always forward the error on to let others see it.
+        context.fireChannelInactive()
+    }
 }


### PR DESCRIPTION
The `channelInactive` callback is triggered when a WebSocket closes without sending a close code. Previously, the `WebSocket.onClose` future was still fulfilled but `WebSocket.isClosed` would be false and `WebSocket.closeCode` would be nil. This would later cause an assertion when `WebSocket` deinitialized.  Now the `onClose` future is still fulfilled, but while also setting `isClosed` and `closeCode` (#60, fixes https://github.com/vapor/vapor/issues/2107).