### PR TITLE
Send correct close code to peer

### DIFF
--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -69,7 +69,7 @@ private final class WebSocketHandler: ChannelInboundHandler {
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-        let closedAbnormally = WebSocketErrorCode.unknown(1005)
+        let closedAbnormally = WebSocketErrorCode.unknown(1006)
         _ = webSocket.close(code: closedAbnormally)
 
         // We always forward the error on to let others see it.


### PR DESCRIPTION
Updates WebSocket close to send correct code to peer according to [RFC6455](https://tools.ietf.org/html/rfc6455#section-7.4) (#67).