### PR TITLE
Automatic WebSocket pings

### DIFF
--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -69,7 +69,7 @@ private final class WebSocketHandler: ChannelInboundHandler {
     }
 
     func channelInactive(context: ChannelHandlerContext) {
-        let closedAbnormally = WebSocketErrorCode.unknown(1005)
+        let closedAbnormally = WebSocketErrorCode.unknown(1006)
         _ = webSocket.close(code: closedAbnormally)
 
         // We always forward the error on to let others see it.


### PR DESCRIPTION
Adds a `pingInterval` property on WebSocket which will trigger automatic pings to the peer to ensure that the connection is still active (#68). 