### PR TITLE
Add NIOT

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -12,6 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.11.1"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.5.1"),
     ],
     targets: [
         .target(name: "WebSocketKit", dependencies: [
@@ -21,6 +22,13 @@ let package = Package(
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOWebSocket", package: "swift-nio"),
+            .product(
+                name: "NIOTransportServices",
+                package: "swift-nio-transport-services",
+                condition: .when(
+                    platforms: [Platform.iOS, Platform.macOS, Platform.tvOS, Platform.watchOS]
+                )
+            )
         ]),
         .testTarget(name: "WebSocketKitTests", dependencies: [
             .target(name: "WebSocketKit"),

--- a/Sources/WebSocketKit/HTTPChannelIntercepter.swift
+++ b/Sources/WebSocketKit/HTTPChannelIntercepter.swift
@@ -1,0 +1,64 @@
+//
+//  File.swift
+//  
+//
+//  Created by Matthaus Woolard on 26/01/2021.
+//
+
+import Foundation
+import NIOHTTP1
+import NIO
+
+public final class HTTPChannelIntercepter: ChannelDuplexHandler, RemovableChannelHandler {
+    
+    public typealias OutboundIn = HTTPClientRequestPart
+    public typealias OutboundOut = HTTPClientRequestPart
+
+    public typealias InboundIn = HTTPClientResponsePart
+    public typealias InboundOut = HTTPClientResponsePart
+    
+    let writeInterceptHandler: (HTTPRequestHead) -> Void
+    
+    public init(writeInterceptHandler: @escaping (HTTPRequestHead) -> Void) {
+        self.writeInterceptHandler = writeInterceptHandler
+    }
+    
+    public func write(
+        context: ChannelHandlerContext,
+        data: NIOAny,
+        promise: EventLoopPromise<Void>?
+    ) {
+        let interceptedOutgoingRequest = self.unwrapOutboundIn(data)
+        
+        if case .head(let requestHead) = interceptedOutgoingRequest {
+            self.writeInterceptHandler(requestHead)
+        }
+        
+        context.write(data, promise: promise)
+    }
+}
+
+extension ChannelPipeline {
+    public func addHTTPClientHandlers(
+        position: Position = .last,
+        leftOverBytesStrategy: RemoveAfterUpgradeStrategy = .dropBytes,
+        withServerUpgrade upgrade: NIOHTTPClientUpgradeConfiguration? = nil,
+        withExtraHandlers extraHandlers: [RemovableChannelHandler] = []
+    ) -> EventLoopFuture<Void> {
+        let requestEncoder = HTTPRequestEncoder()
+        let responseDecoder = HTTPResponseDecoder(leftOverBytesStrategy: leftOverBytesStrategy)
+        
+        var handlers: [RemovableChannelHandler] = [requestEncoder, ByteToMessageHandler(responseDecoder)] + extraHandlers
+        
+        if let (upgraders, completionHandler) = upgrade {
+            let upgrader = NIOHTTPClientUpgradeHandler(
+                upgraders: upgraders,
+                httpHandlers: handlers,
+                upgradeCompletionHandler: completionHandler
+            )
+            handlers.append(upgrader)
+        }
+
+        return self.addHandlers(handlers, position: position)
+    }
+}

--- a/Sources/WebSocketKit/TLSConfiguration+Network.swift
+++ b/Sources/WebSocketKit/TLSConfiguration+Network.swift
@@ -1,0 +1,141 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file was part of the AsyncHTTPClient open source project
+// https://github.com/swift-server/async-http-client
+//
+// Copyright (c) 2020 Apple Inc. and the AsyncHTTPClient project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information 
+// See CONTRIBUTORS.txt for the list of AsyncHTTPClient project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+#if canImport(Network)
+
+    import Foundation
+    import Network
+    import NIOSSL
+    import NIOTransportServices
+
+    extension TLSVersion {
+        /// return Network framework TLS protocol version
+        var nwTLSProtocolVersion: tls_protocol_version_t {
+            switch self {
+            case .tlsv1:
+                return .TLSv10
+            case .tlsv11:
+                return .TLSv11
+            case .tlsv12:
+                return .TLSv12
+            case .tlsv13:
+                return .TLSv13
+            }
+        }
+    }
+
+    extension TLSVersion {
+        /// return as SSL protocol
+        var sslProtocol: SSLProtocol {
+            switch self {
+            case .tlsv1:
+                return .tlsProtocol1
+            case .tlsv11:
+                return .tlsProtocol11
+            case .tlsv12:
+                return .tlsProtocol12
+            case .tlsv13:
+                return .tlsProtocol13
+            }
+        }
+    }
+
+    @available(macOS 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *)
+    extension TLSConfiguration {
+        /// Dispatch queue used by Network framework TLS to control certificate verification
+        static var tlsDispatchQueue = DispatchQueue(label: "TLSDispatch")
+
+        /// create NWProtocolTLS.Options for use with NIOTransportServices from the NIOSSL TLSConfiguration
+        ///
+        /// - Parameter queue: Dispatch queue to run `sec_protocol_options_set_verify_block` on.
+        /// - Returns: Equivalent NWProtocolTLS Options
+        func getNWProtocolTLSOptions() -> NWProtocolTLS.Options {
+            let options = NWProtocolTLS.Options()
+
+            // minimum TLS protocol
+            if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+                sec_protocol_options_set_min_tls_protocol_version(options.securityProtocolOptions, self.minimumTLSVersion.nwTLSProtocolVersion)
+            } else {
+                sec_protocol_options_set_tls_min_version(options.securityProtocolOptions, self.minimumTLSVersion.sslProtocol)
+            }
+
+            // maximum TLS protocol
+            if let maximumTLSVersion = self.maximumTLSVersion {
+                if #available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *) {
+                    sec_protocol_options_set_max_tls_protocol_version(options.securityProtocolOptions, maximumTLSVersion.nwTLSProtocolVersion)
+                } else {
+                    sec_protocol_options_set_tls_max_version(options.securityProtocolOptions, maximumTLSVersion.sslProtocol)
+                }
+            }
+
+            // application protocols
+            for applicationProtocol in self.applicationProtocols {
+                applicationProtocol.withCString { buffer in
+                    sec_protocol_options_add_tls_application_protocol(options.securityProtocolOptions, buffer)
+                }
+            }
+
+            // the certificate chain
+            if self.certificateChain.count > 0 {
+                preconditionFailure("TLSConfiguration.certificateChain is not supported")
+            }
+
+            // cipher suites
+            if self.cipherSuites.count > 0 {
+                // TODO: Requires NIOSSL to provide list of cipher values before we can continue
+                // https://github.com/apple/swift-nio-ssl/issues/207
+            }
+
+            // key log callback
+            if self.keyLogCallback != nil {
+                preconditionFailure("TLSConfiguration.keyLogCallback is not supported")
+            }
+
+            // private key
+            if self.privateKey != nil {
+                preconditionFailure("TLSConfiguration.privateKey is not supported")
+            }
+
+            // renegotiation support key is unsupported
+
+            // trust roots
+            if let trustRoots = self.trustRoots {
+                guard case .default = trustRoots else {
+                    preconditionFailure("TLSConfiguration.trustRoots != .default is not supported")
+                }
+            }
+
+            switch self.certificateVerification {
+            case .none:
+                // add verify block to control certificate verification
+                sec_protocol_options_set_verify_block(
+                    options.securityProtocolOptions,
+                    { _, _, sec_protocol_verify_complete in
+                        sec_protocol_verify_complete(true)
+                    }, TLSConfiguration.tlsDispatchQueue
+                )
+
+            case .noHostnameVerification:
+                precondition(self.certificateVerification != .noHostnameVerification, "TLSConfiguration.certificateVerification = .noHostnameVerification is not supported")
+
+            case .fullVerification:
+                break
+            }
+
+            return options
+        }
+    }
+
+#endif

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -19,6 +19,21 @@ extension WebSocket {
             onUpgrade: onUpgrade
         )
     }
+    
+    public static func connect(
+        to url: String,
+        headers: HTTPHeaders = [:],
+        configuration: WebSocketClient.Configuration = .init(),
+        on eventLoopGroup: EventLoopGroup,
+        onUpgrade: @escaping (WebSocket) -> ()
+    ) -> EventLoopFuture<Void> {
+        return self.connect(
+            to: url,
+            headers: headers,
+            configuration: configuration,
+            on: eventLoopGroup
+        ) { (ws, _ ) in onUpgrade(ws) }
+    }
 
     public static func connect(
         to url: URL,
@@ -38,6 +53,21 @@ extension WebSocket {
             on: eventLoopGroup,
             onUpgrade: onUpgrade
         )
+    }
+    
+    public static func connect(
+        to url: URL,
+        headers: HTTPHeaders = [:],
+        configuration: WebSocketClient.Configuration = .init(),
+        on eventLoopGroup: EventLoopGroup,
+        onUpgrade: @escaping (WebSocket) -> ()
+    ) -> EventLoopFuture<Void> {
+        return self.connect(
+            to: url,
+            headers: headers,
+            configuration: configuration,
+            on: eventLoopGroup
+        ) { (ws, _) in onUpgrade(ws) }
     }
 
     public static func connect(
@@ -61,5 +91,26 @@ extension WebSocket {
             headers: headers,
             onUpgrade: onUpgrade
         )
+    }
+    
+    public static func connect(
+        scheme: String = "ws",
+        host: String,
+        port: Int = 80,
+        path: String = "/",
+        headers: HTTPHeaders = [:],
+        configuration: WebSocketClient.Configuration = .init(),
+        on eventLoopGroup: EventLoopGroup,
+        onUpgrade: @escaping (WebSocket) -> ()
+    ) -> EventLoopFuture<Void> {
+        return self.connect(
+            scheme: scheme,
+            host: host,
+            port: port,
+            path: path,
+            headers: headers,
+            configuration: configuration,
+            on: eventLoopGroup
+        ) { (ws, _) in onUpgrade(ws) }
     }
 }

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -1,10 +1,12 @@
+import NIOHTTP1
+
 extension WebSocket {
     public static func connect(
         to url: String,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket, HTTPResponseHead) -> ()
     ) -> EventLoopFuture<Void> {
         guard let url = URL(string: url) else {
             return eventLoopGroup.next().makeFailedFuture(WebSocketClient.Error.invalidURL)
@@ -23,7 +25,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket, HTTPResponseHead) -> ()
     ) -> EventLoopFuture<Void> {
         let scheme = url.scheme ?? "ws"
         return self.connect(
@@ -46,7 +48,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket, HTTPResponseHead) -> ()
     ) -> EventLoopFuture<Void> {
         return WebSocketClient(
             eventLoopGroupProvider: .shared(eventLoopGroup),

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -123,7 +123,7 @@ public final class WebSocketClient {
         port: Int,
         path: String = "/",
         headers: HTTPHeaders = [:],
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket, HTTPResponseHead) -> ()
     ) -> EventLoopFuture<Void> {
         assert(["ws", "wss"].contains(scheme))
         let upgradePromise = self.group.next().makePromise(of: Void.self)
@@ -152,7 +152,9 @@ public final class WebSocketClient {
                     maxFrameSize: self.configuration.maxFrameSize,
                     automaticErrorHandling: true,
                     upgradePipelineHandler: { channel, req in
-                        return WebSocket.client(on: channel, onUpgrade: onUpgrade)
+                        return WebSocket.client(on: channel) { ws in
+                            onUpgrade(ws, req)
+                        }
                     }
                 )
 

--- a/Tests/WebSocketKitTests/WebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/WebSocketKitTests.swift
@@ -2,13 +2,17 @@ import XCTest
 import NIO
 import NIOHTTP1
 import NIOWebSocket
+#if canImport(Network)
+import NIOTransportServices
+#endif
 @testable import WebSocketKit
 
 final class WebSocketKitTests: XCTestCase {
+    
     func testWebSocketEcho() throws {
-        let promise = elg.next().makePromise(of: String.self)
-        let closePromise = elg.next().makePromise(of: Void.self)
-        WebSocket.connect(to: "ws://echo.websocket.org", on: elg) { ws in
+        let promise = self.remoteEventGroup.next().makePromise(of: String.self)
+        let closePromise = self.remoteEventGroup.next().makePromise(of: Void.self)
+        WebSocket.connect(to: "ws://echo.websocket.org", on: self.remoteEventGroup) { ws in
             ws.send("hello")
             ws.onText { ws, string in
                 promise.succeed(string)
@@ -17,11 +21,12 @@ final class WebSocketKitTests: XCTestCase {
         }.cascadeFailure(to: promise)
         try XCTAssertEqual(promise.futureResult.wait(), "hello")
         XCTAssertNoThrow(try closePromise.futureResult.wait())
+        
     }
     
     func testWebSocketWithTLSEcho() throws {
-        let promise = elg.next().makePromise(of: String.self)
-        WebSocket.connect(to: "wss://echo.websocket.org", on: elg) { ws in
+        let promise = self.remoteEventGroup.next().makePromise(of: String.self)
+        WebSocket.connect(to: "wss://echo.websocket.org", on: self.remoteEventGroup) { ws in
             ws.send("hello")
             ws.onText { ws, string in
                 promise.succeed(string)
@@ -32,7 +37,12 @@ final class WebSocketKitTests: XCTestCase {
     }
 
     func testBadHost() throws {
-        XCTAssertThrowsError(try WebSocket.connect(host: "asdf", on: elg) { _  in }.wait())
+        XCTAssertThrowsError(
+            try WebSocket.connect(
+                host: "asdf",
+                on: self.remoteEventGroup
+            ) { _  in }.wait()
+        )
     }
 
     func testServerClose() throws {
@@ -214,12 +224,29 @@ final class WebSocketKitTests: XCTestCase {
     }
 
     var elg: EventLoopGroup!
+    var remoteEventGroup: EventLoopGroup!
     override func setUp() {
         // needs to be at least two to avoid client / server on same EL timing issues
         self.elg = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        
+        #if canImport(Network)
+            if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+                self.remoteEventGroup = NIOTSEventLoopGroup()
+            } else {
+                self.remoteEventGroup = self.elg
+            }
+        #else
+            self.remoteEventGroup = self.elg
+        #endif
     }
+    
     override func tearDown() {
         try! self.elg.syncShutdownGracefully()
+        #if canImport(Network)
+            if #available(OSX 10.14, iOS 12.0, tvOS 12.0, watchOS 6.0, *) {
+                try! self.remoteEventGroup.syncShutdownGracefully()
+            }
+        #endif
     }
 }
 


### PR DESCRIPTION
# Add NIOTransportServices support on Apple platforms.

On apple platforms it is best to use the `NIOTSEventLoopGroup` and use the corresponding SSL configurations. 

This PR also adds a `HTTPChannelIntercepter` that can be used to inspect the HTTP handshake requests (for locking etc).



