### PR TITLE
Fix deprecation in `WebSocketClient`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 DerivedData
 .swiftpm
 Package.resolved
-

--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.11.1"),
-        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
     ],
     targets: [
         .target(name: "WebSocketKit", dependencies: [

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -93,7 +93,7 @@ public final class WebSocketClient {
                 if scheme == "wss" {
                     do {
                         let context = try NIOSSLContext(
-                            configuration: self.configuration.tlsConfiguration ?? .forClient()
+                            configuration: self.configuration.tlsConfiguration ?? .makeClientConfiguration()
                         )
                         let tlsHandler = try NIOSSLClientHandler(context: context, serverHostname: host)
                         return channel.pipeline.addHandler(tlsHandler).flatMap {


### PR DESCRIPTION
Fix `TLSConfiguration.forClient()` deprecation warning

```
warning: 'forClient(cipherSuites:minimumTLSVersion:maximumTLSVersion:certificateVerification:trustRoots:certificateChain:privateKey:applicationProtocols:shutdownTimeout:keyLogCallback:)' is deprecated: renamed to 'makeClientConfiguration()'
```