### PR TITLE
Persist query parameters in WebSocket URI

### DIFF
--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -31,6 +31,7 @@ extension WebSocket {
             host: url.host ?? "localhost",
             port: url.port ?? (scheme == "wss" ? 443 : 80),
             path: url.path,
+            query: url.query,
             headers: headers,
             configuration: configuration,
             on: eventLoopGroup,
@@ -43,6 +44,7 @@ extension WebSocket {
         host: String,
         port: Int = 80,
         path: String = "/",
+        query: String? = nil,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
@@ -56,6 +58,7 @@ extension WebSocket {
             host: host,
             port: port,
             path: path,
+            query: query,
             headers: headers,
             onUpgrade: onUpgrade
         )

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -54,6 +54,7 @@ public final class WebSocketClient {
         host: String,
         port: Int,
         path: String = "/",
+        query: String? = nil,
         headers: HTTPHeaders = [:],
         onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
@@ -65,6 +66,7 @@ public final class WebSocketClient {
                 let httpHandler = HTTPInitialRequestHandler(
                     host: host,
                     path: path,
+                    query: query,
                     headers: headers,
                     upgradePromise: upgradePromise
                 )


### PR DESCRIPTION
Prevents query parameters passed in the WebSocket URI from being silently dropped on connection (#101, fixes #94).

Calling `WebSocket.connect` with the URI `wss://localhost:443?foo=bar&bar=baz` now sends the full URI, including the query parameters, to the server.