### PR TITLE
Support Codable Messages

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -12,6 +12,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
+        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [
         .target(name: "WebSocketKit", dependencies: [
@@ -22,6 +23,7 @@ let package = Package(
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOWebSocket", package: "swift-nio"),
+            .product(name: "Logging", package: "swift-log")
         ]),
         .testTarget(name: "WebSocketKitTests", dependencies: [
             .target(name: "WebSocketKit"),

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -19,6 +19,12 @@ extension WebSocket {
         return try await promise.futureResult.get()
     }
 
+    public func send<T>(_ data: T, type: WebSocketSendType = .text) async throws where T: Codable {
+        let promise = eventLoop.makePromise(of: Void.self)
+        send(data, type: type, promise: promise)
+        return try await promise.futureResult.get()
+    }
+
     public func sendPing() async throws {
         let promise = eventLoop.makePromise(of: Void.self)
         sendPing(promise: promise)

--- a/Sources/WebSocketKit/Exports.swift
+++ b/Sources/WebSocketKit/Exports.swift
@@ -8,5 +8,3 @@
 @_exported import struct NIOHTTP1.HTTPHeaders
 
 @_exported import struct Foundation.URL
-
-@_exported import Logging

--- a/Sources/WebSocketKit/Exports.swift
+++ b/Sources/WebSocketKit/Exports.swift
@@ -8,3 +8,5 @@
 @_exported import struct NIOHTTP1.HTTPHeaders
 
 @_exported import struct Foundation.URL
+
+@_exported import Logging

--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -46,7 +46,7 @@ public final class WebSocket {
     private var scheduledTimeoutTask: Scheduled<Void>?
     private var events: [String : (WebSocket, Data) -> Void] = [:]
 
-    init(channel: Channel, type: PeerType) {
+    init(channel: Channel, type: PeerType, logger: Logger) {
         self.channel = channel
         self.type = type
         self.onTextCallback = { _, _ in }
@@ -56,7 +56,7 @@ public final class WebSocket {
         self.waitingForPong = false
         self.waitingForClose = false
         self.scheduledTimeoutTask = nil
-        self.logger = Logger(label: "codes.vapor.websocket")
+        self.logger = logger
     }
 
     public func onText(_ callback: @escaping (WebSocket, String) -> ()) {

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -4,6 +4,7 @@ import NIOConcurrencyHelpers
 import NIOHTTP1
 import NIOWebSocket
 import NIOSSL
+import Logging
 
 public final class WebSocketClient {
     public enum Error: Swift.Error, LocalizedError {
@@ -37,8 +38,9 @@ public final class WebSocketClient {
     let group: EventLoopGroup
     let configuration: Configuration
     let isShutdown = NIOAtomic.makeAtomic(value: false)
+    let logger: Logger
 
-    public init(eventLoopGroupProvider: EventLoopGroupProvider, configuration: Configuration = .init()) {
+    public init(eventLoopGroupProvider: EventLoopGroupProvider, configuration: Configuration = .init(), logger: Logger = Logger(label: "codes.vapor.websocket")) {
         self.eventLoopGroupProvider = eventLoopGroupProvider
         switch self.eventLoopGroupProvider {
         case .shared(let group):
@@ -47,6 +49,7 @@ public final class WebSocketClient {
             self.group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         }
         self.configuration = configuration
+        self.logger = logger
     }
 
     public func connect(
@@ -80,7 +83,7 @@ public final class WebSocketClient {
                     maxFrameSize: self.configuration.maxFrameSize,
                     automaticErrorHandling: true,
                     upgradePipelineHandler: { channel, req in
-                        return WebSocket.client(on: channel, onUpgrade: onUpgrade)
+                        return WebSocket.client(on: channel, logger: self.logger, onUpgrade: onUpgrade)
                     }
                 )
 

--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -1,27 +1,50 @@
 import NIO
 import NIOWebSocket
+import Logging
 
 extension WebSocket {
+
+    @available(*, deprecated, message: "use Websocket.client(on:logger:onUpgrade:)")
     public static func client(
         on channel: Channel,
         onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
-        return self.handle(on: channel, as: .client, onUpgrade: onUpgrade)
+        let logger = Logger(label: "codes.vapor.websocket")
+        return self.handle(on: channel, as: .client, logger: logger, onUpgrade: onUpgrade)
     }
 
+    @available(*, deprecated, message: "use Websocket.server(on:logger:onUpgrade:)")
     public static func server(
         on channel: Channel,
         onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
-        return self.handle(on: channel, as: .server, onUpgrade: onUpgrade)
+        let logger = Logger(label: "codes.vapor.websocket")
+        return self.handle(on: channel, as: .server, logger: logger, onUpgrade: onUpgrade)
+    }
+
+    public static func client(
+        on channel: Channel,
+        logger: Logger,
+        onUpgrade: @escaping (WebSocket) -> ()
+    ) -> EventLoopFuture<Void> {
+        return self.handle(on: channel, as: .client, logger: logger, onUpgrade: onUpgrade)
+    }
+
+    public static func server(
+        on channel: Channel,
+        logger: Logger,
+        onUpgrade: @escaping (WebSocket) -> ()
+    ) -> EventLoopFuture<Void> {
+        return self.handle(on: channel, as: .server, logger: logger, onUpgrade: onUpgrade)
     }
 
     private static func handle(
         on channel: Channel,
         as type: PeerType,
+        logger: Logger,
         onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
-        let webSocket = WebSocket(channel: channel, type: type)
+        let webSocket = WebSocket(channel: channel, type: type, logger: logger)
         return channel.pipeline.addHandler(WebSocketHandler(webSocket: webSocket)).map { _ in
             onUpgrade(webSocket)
         }

--- a/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
@@ -55,13 +55,11 @@ final class AsyncWebSocketKitTests: XCTestCase {
             return
         }
 
-        let promise = elg.next().makePromise(of: String.self)
-
         try await WebSocket.connect(to: "ws://localhost:\(port)", on: elg) { ws in
             do {
                 try await ws.send(Response(event: "hello", data: User(firstName: "Vapor", lastName: "WebSocket")))
                 ws.onText { ws, string in
-                    promise.succeed(string)
+                    XCTAssertEqual(string, "Hello Vapor WebSocket")
                     do {
                         try await ws.close()
                     } catch {
@@ -69,12 +67,10 @@ final class AsyncWebSocketKitTests: XCTestCase {
                     }
                 }
             } catch {
-                promise.fail(error)
+                XCTFail("Failed to connect, error: \(error)")
             }
         }
 
-        let result = try await promise.futureResult.get()
-        XCTAssertEqual(result, "Hello Vapor WebSocket")
         try await server.close(mode: .all)
 
         struct Response: Codable {

--- a/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
@@ -3,12 +3,13 @@ import XCTest
 import NIO
 import NIOHTTP1
 import NIOWebSocket
+import Logging
 @testable import WebSocketKit
 
 @available(macOS 12, iOS 15, watchOS 8, tvOS 15, *)
 final class AsyncWebSocketKitTests: XCTestCase {
     func testWebSocketEcho() async throws {
-        let server = try ServerBootstrap.webSocket(on: self.elg) { req, ws in
+        let server = try ServerBootstrap.webSocket(on: self.elg, logger: self.logger) { req, ws in
             ws.onText { ws, text in
                 ws.send(text)
             }
@@ -43,7 +44,7 @@ final class AsyncWebSocketKitTests: XCTestCase {
     }
 
     func testWebSocketSendCodable() async throws {
-        let server = try ServerBootstrap.webSocket(on: self.elg) { req, ws in
+        let server = try ServerBootstrap.webSocket(on: self.elg, logger: self.logger) { req, ws in
             ws.onEvent("hello", User.self) { ws, user in
                 ws.send("Hello \(user.firstName) \(user.lastName)")
             }
@@ -87,9 +88,11 @@ final class AsyncWebSocketKitTests: XCTestCase {
     }
 
     var elg: EventLoopGroup!
+    var logger: Logger!
     override func setUp() {
         // needs to be at least two to avoid client / server on same EL timing issues
         self.elg = MultiThreadedEventLoopGroup(numberOfThreads: 2)
+        self.logger = Logger(label: "com.vapor.websocketkit.tests")
     }
     override func tearDown() {
         try! self.elg.syncShutdownGracefully()


### PR DESCRIPTION
(#103,  fixes #62).

Many Thanks to @MihaelIsaev  for the [inspiration](https://github.com/MihaelIsaev/AwesomeWS)!

Those changes adds support to send `Codable` messages and receive events in special JSON format:

`{ "event": "<event name>" }`
or
`{ "event": "<event name>", "data": <anything> }`

The event `data` will be decoded to the provided `Type`.

Here is a demo:
```swift
struct WebSocketController: RouteCollection {
	func boot(routes: RoutesBuilder) throws {
		routes.webSocket("chat") { req, ws in
			ws.onEvent("hello", helloHandler)

			ws.onEvent("bye", Bye.self) { ws, data in
				print("Bye \(data.firstName) \(data.lastName)")
				ws.send(Response(status: "Bye bye!"))
			}

			ws.onText { ws, text in
				print(text)
			}

			ws.onEvent("stop") { ws in
				// stop event without data
			}

			ws.onEvent("start", startHandler)
		}
	}
}

// MARK: - WebSocket Event Handlers
extension WebSocketController {
	func helloHandler(webSocket: WebSocket, data: Hello) {
		print("Hello \(data.firstName) \(data.lastName)")
		webSocket.send(Response(status: "Hey There \(data.firstName) \(data.lastName)"), type: .binary)
	}

	func startHandler(webSocket: WebSocket) {
		// start event
	}
}

// MARK: - Codables
struct Hello: Codable {
	let firstName, lastName: String
}

struct Bye: Codable {
	let firstName, lastName: String
}

struct Response: Codable {
	let status: String
}
```

The code will become much cleaner as you can give on events a handler!