### PR TITLE
Update good first issue workflow to work for multiple labels

### DIFF
--- a/.github/workflows/projectboard.yml
+++ b/.github/workflows/projectboard.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
       - id: set-matrix 
         run: |
-          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name')
+          output=$(curl ${{ github.event.issue.url }}/labels | jq '.[] | .name') || output=""
 
           echo '======================'
           echo 'Process incoming data'


### PR DESCRIPTION
This pr updates the project board workflow to use the reusable workflow defined in the [Vapor CI repository](https://github.com/vapor/ci).