### PR TITLE
Update Supported Swift Versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,23 +2,14 @@ name: test
 on:
 - pull_request
 jobs:
-  websocket-kit_xenial:
-    container: 
-      image: vapor/swift:5.2-xenial
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
-  websocket-kit_bionic:
-    container: 
-      image: vapor/swift:5.2-bionic
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v1
-    - run: swift test --enable-test-discovery --sanitize=thread
+  unit-tests:
+     uses: vapor/ci/.github/workflows/run-unit-tests.yml@reusable-workflows
+     with:
+       with_coverage: false
+       with_tsan: true
   vapor:
     container: 
-      image: vapor/swift:5.2
+      image: swift:5.6-focal
     runs-on: ubuntu-latest
     steps:
     - run: git clone -b main https://github.com/vapor/vapor.git

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.2
+// swift-tools-version:5.4
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
This removes support for Swift 5.2 and Swift 5.3, making Swift 5.4 the earliest supported version [as announced](https://blog.vapor.codes/posts/vapor-swift-versions-update/)