### PR TITLE
Make sure onPing is called and account for control frames being able to be interspersed with message fragments

### DIFF
--- a/Tests/WebSocketKitTests/WebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/WebSocketKitTests.swift
@@ -126,8 +126,7 @@ final class WebSocketKitTests: XCTestCase {
         let pingPongData = ByteBuffer(bytes: "Vapor rules".utf8)
         
         let server = try ServerBootstrap.webSocket(on: self.elg) { req, ws in
-            ws.onPing { ws, frame in
-                XCTAssertEqual(frame, pingPongData)
+            ws.onPing { ws in
                 pingPromise.succeed("ping")
             }
         }.bind(host: "localhost", port: 0).wait()
@@ -139,8 +138,7 @@ final class WebSocketKitTests: XCTestCase {
 
         WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { ws in
             ws.send(raw: pingPongData.readableBytesView, opcode: .ping)
-            ws.onPong { ws, frame in
-                XCTAssertEqual(frame, pingPongData)
+            ws.onPong { ws in
                 pongPromise.succeed("pong")
                 ws.close(promise: nil)
             }


### PR DESCRIPTION
Control frames can appear in the middle of fragmented messages. Therefor they must not be part of the `frameSequence`. Also expose the frame data of the control frames, as that might be usable application data.

Before this PR, `onPing` was never called at all.

<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
