### PR TITLE
Pass a copy of the control frame buffer to ping/pong callbacks

### DIFF
--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -60,21 +60,21 @@ extension WebSocket {
         }
     }
 
-    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
         self.eventLoop.execute {
-            self.onPong { socket in
+            self.onPong { socket, data in
                 Task {
-                    await callback(socket)
+                    await callback(socket, data)
                 }
             }
         }
     }
 
-    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
         self.eventLoop.execute {
-            self.onPing { socket in
+            self.onPing { socket, data in
                 Task {
-                    await callback(socket)
+                    await callback(socket, data)
                 }
             }
         }

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -18,7 +18,11 @@ extension WebSocket {
         return try await promise.futureResult.get()
     }
 
-    public func sendPing(_ data: Data = Data()) async throws {
+    public func sendPing() async throws {
+        try await sendPing(Data())
+    }
+
+    public func sendPing(_ data: Data) async throws {
         let promise = eventLoop.makePromise(of: Void.self)
         sendPing(data, promise: promise)
         return try await promise.futureResult.get()

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -18,9 +18,9 @@ extension WebSocket {
         return try await promise.futureResult.get()
     }
 
-    public func sendPing() async throws {
+    public func sendPing(_ data: Data = Data()) async throws {
         let promise = eventLoop.makePromise(of: Void.self)
-        sendPing(promise: promise)
+        sendPing(data, promise: promise)
         return try await promise.futureResult.get()
     }
 

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -69,12 +69,34 @@ extension WebSocket {
             }
         }
     }
+    
+    @available(*, deprecated, message: "Please use `onPong { socket, data in /* … */ }` with the additional `data` parameter.")
+    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+        self.eventLoop.execute {
+            self.onPong { socket, _ in
+                Task {
+                    await callback(socket)
+                }
+            }
+        }
+    }
 
     @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
         self.eventLoop.execute {
             self.onPing { socket, data in
                 Task {
                     await callback(socket, data)
+                }
+            }
+        }
+    }
+    
+    @available(*, deprecated, message: "Please use `onPing { socket, data in /* … */ }` with the additional `data` parameter.")
+    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+        self.eventLoop.execute {
+            self.onPing { socket, _ in
+                Task {
+                    await callback(socket)
                 }
             }
         }

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -64,7 +64,7 @@ extension WebSocket {
         }
     }
 
-    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
+    public func onPong(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
         self.eventLoop.execute {
             self.onPong { socket, data in
                 Task {
@@ -85,7 +85,7 @@ extension WebSocket {
         }
     }
 
-    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
+    public func onPing(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
         self.eventLoop.execute {
             self.onPing { socket, data in
                 Task {

--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -66,7 +66,7 @@ public final class WebSocket: Sendable {
         self.onBinaryCallback.value = callback
     }
     
-    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
+    public func onPong(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
         self.onPongCallback.value = callback
     }
     
@@ -75,7 +75,7 @@ public final class WebSocket: Sendable {
         self.onPongCallback.value = { ws, _ in callback(ws) }
     }
 
-    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
+    public func onPing(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
         self.onPingCallback.value = callback
     }
     

--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -121,9 +121,9 @@ public final class WebSocket: Sendable {
         self.send(raw: binary, opcode: .binary, fin: true, promise: promise)
     }
 
-    public func sendPing(promise: EventLoopPromise<Void>? = nil) {
+    public func sendPing(_ data: Data = Data(), promise: EventLoopPromise<Void>? = nil) {
         self.send(
-            raw: Data(),
+            raw: data,
             opcode: .ping,
             fin: true,
             promise: promise

--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -121,7 +121,11 @@ public final class WebSocket: Sendable {
         self.send(raw: binary, opcode: .binary, fin: true, promise: promise)
     }
 
-    public func sendPing(_ data: Data = Data(), promise: EventLoopPromise<Void>? = nil) {
+    public func sendPing(promise: EventLoopPromise<Void>? = nil) {
+        sendPing(Data(), promise: promise)
+    }
+
+    public func sendPing(_ data: Data, promise: EventLoopPromise<Void>? = nil) {
         self.send(
             raw: data,
             opcode: .ping,

--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -69,9 +69,19 @@ public final class WebSocket: Sendable {
     @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
         self.onPongCallback.value = callback
     }
+    
+    @available(*, deprecated, message: "Please use `onPong { socket, data in /* … */ }` with the additional `data` parameter.")
+    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket) -> ()) {
+        self.onPongCallback.value = { ws, _ in callback(ws) }
+    }
 
     @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
         self.onPingCallback.value = callback
+    }
+    
+    @available(*, deprecated, message: "Please use `onPing { socket, data in /* … */ }` with the additional `data` parameter.")
+    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket) -> ()) {
+        self.onPingCallback.value = { ws, _ in callback(ws) }
     }
 
     /// If set, this will trigger automatic pings on the connection. If ping is not answered before

--- a/Tests/WebSocketKitTests/WebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/WebSocketKitTests.swift
@@ -145,7 +145,7 @@ final class WebSocketKitTests: XCTestCase {
         }
 
         WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { ws in
-            ws.send(raw: pingPongData.readableBytesView, opcode: .ping)
+            ws.sendPing(Data(pingPongData.readableBytesView))
             ws.onPong { ws, data in
                 XCTAssertEqual(pingPongData, data)
                 pongPromise.succeed("pong")

--- a/Tests/WebSocketKitTests/WebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/WebSocketKitTests.swift
@@ -133,7 +133,8 @@ final class WebSocketKitTests: XCTestCase {
         let pingPongData = ByteBuffer(bytes: "Vapor rules".utf8)
 
         let server = try ServerBootstrap.webSocket(on: self.elg) { req, ws in
-            ws.onPing { ws in
+            ws.onPing { ws, data in
+                XCTAssertEqual(pingPongData, data)
                 pingPromise.succeed("ping")
             }
         }.bind(host: "localhost", port: 0).wait()
@@ -144,7 +145,9 @@ final class WebSocketKitTests: XCTestCase {
         }
 
         WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { ws in
-            ws.onPong { ws in
+            ws.send(raw: pingPongData.readableBytesView, opcode: .ping)
+            ws.onPong { ws, data in
+                XCTAssertEqual(pingPongData, data)
                 pongPromise.succeed("pong")
                 ws.close(promise: nil)
             }


### PR DESCRIPTION
This PR enables access to the data in the control frames handled via `onPing`/`onPong` via a new API with the existing `onPing` and `onPong` methods being deprecated.