### PR TITLE
Enable compilation on iOS

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,8 @@ import PackageDescription
 let package = Package(
     name: "websocket-kit",
     platforms: [
-       .macOS(.v10_15)
+       .macOS(.v10_15),
+       .iOS(.v11)
     ],
     products: [
         .library(name: "WebSocketKit", targets: ["WebSocketKit"]),


### PR DESCRIPTION
This adds experimental support for building WebsocketKit on iOS from iOS 11 onwards

Closing #117

