### PR TITLE
Remove use of NIOAtomics in favor of Atomics

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -15,6 +15,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.33.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.14.0"),
         .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
     targets: [
         .target(name: "WebSocketKit", dependencies: [
@@ -26,6 +27,7 @@ let package = Package(
             .product(name: "NIOSSL", package: "swift-nio-ssl"),
             .product(name: "NIOWebSocket", package: "swift-nio"),
             .product(name: "NIOTransportServices", package: "swift-nio-transport-services"),
+            .product(name: "Atomics", package: "swift-atomics")
         ]),
         .testTarget(name: "WebSocketKitTests", dependencies: [
             .target(name: "WebSocketKit"),


### PR DESCRIPTION
### The Problem
Starting with [`SwiftNIO` 2.41.0](https://github.com/apple/swift-nio/releases/tag/2.41.0), `NIOAtomics` is deprecated in favor of `Atomics`.
This produces a warning if you use `SwiftNIO` 2.41.0 or higher.

### Modifications
This PR add a dependency to `Atomics` to change the only use of `NIOAtomics` to `Atomics`, and suppress the warning.

### What Warning?!
```
path/to/package/.build/checkouts/websocket-kit/Sources/WebSocketKit/WebSocketClient.swift:40:22: warning: 'NIOAtomic' is deprecated: please use ManagedAtomic from https://github.com/apple/swift-atomics instead
    let isShutdown = NIOAtomic.makeAtomic(value: false)
                     ^
```
