### PR TITLE
Updated WebSocketClient to use ManagedAtomic instead of NIO.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -20,7 +20,6 @@ let package = Package(
         .target(name: "WebSocketKit", dependencies: [
             .product(name: "NIO", package: "swift-nio"),
             .product(name: "NIOCore", package: "swift-nio"),
-            .product(name: "NIOConcurrencyHelpers", package: "swift-nio"),
             .product(name: "NIOFoundationCompat", package: "swift-nio"),
             .product(name: "NIOHTTP1", package: "swift-nio"),
             .product(name: "NIOSSL", package: "swift-nio-ssl"),


### PR DESCRIPTION
Fixes #121

Ordering is based on the ordering specified in the comments of NIOAtomic compareAndExchange() and load().

<!-- 🚀 Thank you for contributing! -->

Replaced the sole instance of `NIOAtomic.makeAtomic(value:)` with `ManagedAtomic<Bool>(_:)`, as well as the two accessed methods `compareAndExchange()` and `load()`. The new atomics require specifying the memory ordering. Based on the comments in NIOConcurrencyHelpers, the compare-and-exchange is done with `.sequentiallyConsistent` ordering, and the load is done with `.relaxed`.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
