### PR TITLE
Do not add a `Content-Type` header to the HTTP upgrade request

### DIFF
--- a/Sources/WebSocketKit/HTTPInitialRequestHandler.swift
+++ b/Sources/WebSocketKit/HTTPInitialRequestHandler.swift
@@ -21,7 +21,6 @@ final class HTTPInitialRequestHandler: ChannelInboundHandler, RemovableChannelHa
 
     func channelActive(context: ChannelHandlerContext) {
         var headers = self.headers
-        headers.add(name: "Content-Type", value: "text/plain; charset=utf-8")
         headers.add(name: "Host", value: self.host)
 
         var uri = self.path.hasPrefix("/") ? self.path : "/" + self.path


### PR DESCRIPTION
⚠️ **WARNING**: This release removes the hard-coded `content-type` header from the upgrade request. If you were relying on this you'll need to manually add it now, but since there's no body it shouldn't be required

[Some](https://alpaca.markets/docs/api-references/trading-api/streaming/) WebSocket servers use the `Content-Type` header to determine which serialization format to use for its WebSocket messages. However, `HTTPInitialRequestHandler` [adds](https://github.com/vapor/websocket-kit/blob/62f568aa9d338aa33790534fa7b5800976f93af8/Sources/WebSocketKit/HTTPInitialRequestHandler.swift#L24) a hard-coded `Content-Type: text/plain; charset=utf-8` header to the WebSocket client’s HTTP upgrade request, so the client cannot customize the header value.

Given that the HTTP upgrade request body is empty, there is no need for `HTTPInitialRequestHandler` to add the `Content-Type` header. This will allow the client to add their own, if desired.

Fixes #126.