### PR TITLE
Revert "Add Sendable conformances to WebsocketKit (#131)"

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,9 @@ concurrency:
 on:
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
+
 jobs:
+
   vapor-integration:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 DerivedData
 .swiftpm
 Package.resolved
-.devcontainer/

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.16.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.24.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.16.0"),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
     ],
     targets: [
         .target(name: "WebSocketKit", dependencies: [

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -40,42 +40,34 @@ extension WebSocket {
         try await close(code: code).get()
     }
 
-    public func onText(_ callback: @Sendable @escaping (WebSocket, String) async -> ()) {
-        self.eventLoop.execute {
-            self.onText { socket, text in
-                Task {
-                    await callback(socket, text)
-                }
+    public func onText(_ callback: @escaping (WebSocket, String) async -> ()) {
+        onText { socket, text in
+            Task {
+                await callback(socket, text)
             }
         }
     }
 
-    public func onBinary(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
-        self.eventLoop.execute {
-            self.onBinary { socket, binary in
-                Task {
-                    await callback(socket, binary)
-                }
+    public func onBinary(_ callback: @escaping (WebSocket, ByteBuffer) async -> ()) {
+        onBinary { socket, binary in
+            Task {
+                await callback(socket, binary)
             }
         }
     }
 
-    public func onPong(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
-        self.eventLoop.execute {
-            self.onPong { socket in
-                Task {
-                    await callback(socket)
-                }
+    public func onPong(_ callback: @escaping (WebSocket) async -> ()) {
+        onPong { socket in
+            Task {
+                await callback(socket)
             }
         }
     }
 
-    public func onPing(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
-        self.eventLoop.execute {
-            self.onPing { socket in
-                Task {
-                    await callback(socket)
-                }
+    public func onPing(_ callback: @escaping (WebSocket) async -> ()) {
+        onPing { socket in
+            Task {
+                await callback(socket)
             }
         }
     }
@@ -85,7 +77,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) async -> ()
+        onUpgrade: @escaping (WebSocket) async -> ()
     ) async throws {
         return try await self.connect(
             to: url,
@@ -105,7 +97,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) async -> ()
+        onUpgrade: @escaping (WebSocket) async -> ()
     ) async throws {
         return try await self.connect(
             to: url,
@@ -129,7 +121,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) async -> ()
+        onUpgrade: @escaping (WebSocket) async -> ()
     ) async throws {
         return try await self.connect(
             scheme: scheme,

--- a/Sources/WebSocketKit/Exports.swift
+++ b/Sources/WebSocketKit/Exports.swift
@@ -6,7 +6,9 @@
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoopGroup
 @_documentation(visibility: internal) @_exported import struct NIOCore.EventLoopPromise
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
+
 @_documentation(visibility: internal) @_exported import struct NIOHTTP1.HTTPHeaders
+
 @_documentation(visibility: internal) @_exported import struct Foundation.URL
 
 #else
@@ -17,7 +19,9 @@
 @_exported import protocol NIOCore.EventLoopGroup
 @_exported import struct NIOCore.EventLoopPromise
 @_exported import class NIOCore.EventLoopFuture
+
 @_exported import struct NIOHTTP1.HTTPHeaders
+
 @_exported import struct Foundation.URL
 
 #endif

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -17,7 +17,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         guard let url = URL(string: url) else {
             return eventLoopGroup.any().makeFailedFuture(WebSocketClient.Error.invalidURL)
@@ -45,7 +45,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         let scheme = url.scheme ?? "ws"
         return self.connect(
@@ -83,7 +83,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return WebSocketClient(
             eventLoopGroupProvider: .shared(eventLoopGroup),
@@ -129,7 +129,7 @@ extension WebSocket {
         proxyConnectDeadline: NIODeadline = NIODeadline.distantFuture,
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return WebSocketClient(
             eventLoopGroupProvider: .shared(eventLoopGroup),
@@ -171,7 +171,7 @@ extension WebSocket {
         proxyConnectDeadline: NIODeadline = NIODeadline.distantFuture,
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         guard let url = URL(string: url) else {
             return eventLoopGroup.any().makeFailedFuture(WebSocketClient.Error.invalidURL)

--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -4,10 +4,9 @@ import NIOHTTP1
 import NIOSSL
 import Foundation
 import NIOFoundationCompat
-import NIOConcurrencyHelpers
 
-public final class WebSocket: Sendable {
-    enum PeerType: Sendable {
+public final class WebSocket {
+    enum PeerType {
         case server
         case client
     }
@@ -19,11 +18,7 @@ public final class WebSocket: Sendable {
     public var isClosed: Bool {
         !self.channel.isActive
     }
-    public var closeCode: WebSocketErrorCode? {
-        _closeCode.withLockedValue { $0 }
-    }
-    
-    private let _closeCode: NIOLockedValueBox<WebSocketErrorCode?>
+    public private(set) var closeCode: WebSocketErrorCode?
 
     public var onClose: EventLoopFuture<Void> {
         self.channel.closeFuture
@@ -32,46 +27,42 @@ public final class WebSocket: Sendable {
     @usableFromInline
     /* private but @usableFromInline */
     internal let channel: Channel
-    private let onTextCallback: NIOLoopBoundBox<@Sendable (WebSocket, String) -> ()>
-    private let onBinaryCallback: NIOLoopBoundBox<@Sendable (WebSocket, ByteBuffer) -> ()>
-    private let onPongCallback: NIOLoopBoundBox<@Sendable (WebSocket) -> ()>
-    private let onPingCallback: NIOLoopBoundBox<@Sendable (WebSocket) -> ()>
+    private var onTextCallback: (WebSocket, String) -> ()
+    private var onBinaryCallback: (WebSocket, ByteBuffer) -> ()
+    private var onPongCallback: (WebSocket) -> ()
+    private var onPingCallback: (WebSocket) -> ()
+    private var frameSequence: WebSocketFrameSequence?
     private let type: PeerType
-    private let waitingForPong: NIOLockedValueBox<Bool>
-    private let waitingForClose: NIOLockedValueBox<Bool>
-    private let scheduledTimeoutTask: NIOLockedValueBox<Scheduled<Void>?>
-    private let frameSequence: NIOLockedValueBox<WebSocketFrameSequence?>
-    private let _pingInterval: NIOLockedValueBox<TimeAmount?>
+    private var waitingForPong: Bool
+    private var waitingForClose: Bool
+    private var scheduledTimeoutTask: Scheduled<Void>?
 
     init(channel: Channel, type: PeerType) {
         self.channel = channel
         self.type = type
-        self.onTextCallback = .init({ _, _ in }, eventLoop: channel.eventLoop)
-        self.onBinaryCallback = .init({ _, _ in }, eventLoop: channel.eventLoop)
-        self.onPongCallback = .init({ _ in }, eventLoop: channel.eventLoop)
-        self.onPingCallback = .init({ _ in }, eventLoop: channel.eventLoop)
-        self.waitingForPong = .init(false)
-        self.waitingForClose = .init(false)
-        self.scheduledTimeoutTask = .init(nil)
-        self._closeCode = .init(nil)
-        self.frameSequence = .init(nil)
-        self._pingInterval = .init(nil)
+        self.onTextCallback = { _, _ in }
+        self.onBinaryCallback = { _, _ in }
+        self.onPongCallback = { _ in }
+        self.onPingCallback = { _ in }
+        self.waitingForPong = false
+        self.waitingForClose = false
+        self.scheduledTimeoutTask = nil
     }
 
-    public func onText(_ callback: @Sendable @escaping (WebSocket, String) -> ()) {
-        self.onTextCallback.value = callback
+    public func onText(_ callback: @escaping (WebSocket, String) -> ()) {
+        self.onTextCallback = callback
     }
 
-    public func onBinary(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
-        self.onBinaryCallback.value = callback
+    public func onBinary(_ callback: @escaping (WebSocket, ByteBuffer) -> ()) {
+        self.onBinaryCallback = callback
     }
     
-    public func onPong(_ callback: @Sendable @escaping (WebSocket) -> ()) {
-        self.onPongCallback.value = callback
+    public func onPong(_ callback: @escaping (WebSocket) -> ()) {
+        self.onPongCallback = callback
     }
 
-    public func onPing(_ callback: @Sendable @escaping (WebSocket) -> ()) {
-        self.onPingCallback.value = callback
+    public func onPing(_ callback: @escaping (WebSocket) -> ()) {
+        self.onPingCallback = callback
     }
 
     /// If set, this will trigger automatic pings on the connection. If ping is not answered before
@@ -81,18 +72,14 @@ public final class WebSocket: Sendable {
     /// mechanism shutting down inactive connections, such as a Load Balancer deployed in
     /// front of the server.
     public var pingInterval: TimeAmount? {
-        get {
-            return _pingInterval.withLockedValue { $0 }
-        }
-        set {
-            _pingInterval.withLockedValue { $0 = newValue }
-            if newValue != nil {
-                if scheduledTimeoutTask.withLockedValue({ $0 == nil }) {
-                    waitingForPong.withLockedValue { $0 = false }
+        didSet {
+            if pingInterval != nil {
+                if scheduledTimeoutTask == nil {
+                    waitingForPong = false
                     self.pingAndScheduleNextTimeoutTask()
                 }
             } else {
-                scheduledTimeoutTask.withLockedValue { $0?.cancel() }
+                scheduledTimeoutTask?.cancel()
             }
         }
     }
@@ -173,12 +160,12 @@ public final class WebSocket: Sendable {
             promise?.succeed(())
             return
         }
-        guard !self.waitingForClose.withLockedValue({ $0 }) else {
+        guard !self.waitingForClose else {
             promise?.succeed(())
             return
         }
-        self.waitingForClose.withLockedValue { $0 = true }
-        self._closeCode.withLockedValue { $0 = code }
+        self.waitingForClose = true
+        self.closeCode = code
 
         let codeAsInt = UInt16(webSocketErrorCode: code)
         let codeToSend: WebSocketErrorCode
@@ -210,7 +197,7 @@ public final class WebSocket: Sendable {
     func handle(incoming frame: WebSocketFrame) {
         switch frame.opcode {
         case .connectionClose:
-            if self.waitingForClose.withLockedValue({ $0 }) {
+            if self.waitingForClose {
                 // peer confirmed close, time to close channel
                 self.channel.close(mode: .all, promise: nil)
             } else {
@@ -236,7 +223,7 @@ public final class WebSocket: Sendable {
                 if let maskingKey = maskingKey {
                     frameData.webSocketUnmask(maskingKey)
                 }
-                self.onPingCallback.value(self)
+                self.onPingCallback(self)
                 self.send(
                     raw: frameData.readableBytesView,
                     opcode: .pong,
@@ -253,19 +240,22 @@ public final class WebSocket: Sendable {
                 if let maskingKey = maskingKey {
                     frameData.webSocketUnmask(maskingKey)
                 }
-                self.waitingForPong.withLockedValue { $0 = false }
-                self.onPongCallback.value(self)
+                self.waitingForPong = false
+                self.onPongCallback(self)
             } else {
                 self.close(code: .protocolError, promise: nil)
             }
         case .text, .binary:
             // create a new frame sequence or use existing
-            self.frameSequence.withLockedValue { currentFrameSequence in
-                var frameSequence = currentFrameSequence ?? .init(type: frame.opcode)
-                // append this frame and update the sequence
-                frameSequence.append(frame)
-                currentFrameSequence = frameSequence
+            var frameSequence: WebSocketFrameSequence
+            if let existing = self.frameSequence {
+                frameSequence = existing
+            } else {
+                frameSequence = WebSocketFrameSequence(type: frame.opcode)
             }
+            // append this frame and update the sequence
+            frameSequence.append(frame)
+            self.frameSequence = frameSequence
         case .continuation:
             /// continuations are filtered by ``NIOWebSocketFrameAggregator``
             preconditionFailure("We will never receive a continuation frame")
@@ -276,29 +266,26 @@ public final class WebSocket: Sendable {
 
         // if this frame was final and we have a non-nil frame sequence,
         // output it to the websocket and clear storage
-        self.frameSequence.withLockedValue { currentFrameSequence in
-            if let frameSequence = currentFrameSequence, frame.fin {
-                switch frameSequence.type {
-                case .binary:
-                    self.onBinaryCallback.value(self, frameSequence.binaryBuffer)
-                case .text:
-                    self.onTextCallback.value(self, frameSequence.textBuffer)
-                case .ping, .pong:
-                    assertionFailure("Control frames never have a frameSequence")
-                default: break
-                }
-                currentFrameSequence = nil
+        if let frameSequence = self.frameSequence, frame.fin {
+            switch frameSequence.type {
+            case .binary:
+                self.onBinaryCallback(self, frameSequence.binaryBuffer)
+            case .text:
+                self.onTextCallback(self, frameSequence.textBuffer)
+            case .ping, .pong:
+                assertionFailure("Control frames never have a frameSequence")
+            default: break
             }
+            self.frameSequence = nil
         }
     }
 
-    @Sendable
     private func pingAndScheduleNextTimeoutTask() {
         guard channel.isActive, let pingInterval = pingInterval else {
             return
         }
 
-        if waitingForPong.withLockedValue({ $0 }) {
+        if waitingForPong {
             // We never received a pong from our last ping, so the connection has timed out
             let promise = self.eventLoop.makePromise(of: Void.self)
             self.close(code: .unknown(1006), promise: promise)
@@ -311,13 +298,11 @@ public final class WebSocket: Sendable {
             }
         } else {
             self.sendPing()
-            self.waitingForPong.withLockedValue { $0 = true }
-            self.scheduledTimeoutTask.withLockedValue {
-                $0 = self.eventLoop.scheduleTask(
-                    deadline: .now() + pingInterval,
-                    self.pingAndScheduleNextTimeoutTask
-                )
-            }
+            self.waitingForPong = true
+            self.scheduledTimeoutTask = self.eventLoop.scheduleTask(
+                deadline: .now() + pingInterval,
+                self.pingAndScheduleNextTimeoutTask
+            )
         }
     }
 
@@ -326,31 +311,27 @@ public final class WebSocket: Sendable {
     }
 }
 
-private struct WebSocketFrameSequence: Sendable {
+private struct WebSocketFrameSequence {
     var binaryBuffer: ByteBuffer
     var textBuffer: String
-    let type: WebSocketOpcode
-    let lock: NIOLock
+    var type: WebSocketOpcode
 
     init(type: WebSocketOpcode) {
         self.binaryBuffer = ByteBufferAllocator().buffer(capacity: 0)
         self.textBuffer = .init()
         self.type = type
-        self.lock = .init()
     }
 
     mutating func append(_ frame: WebSocketFrame) {
-        self.lock.withLockVoid {
-            var data = frame.unmaskedData
-            switch type {
-            case .binary:
-                self.binaryBuffer.writeBuffer(&data)
-            case .text:
-                if let string = data.readString(length: data.readableBytes) {
-                    self.textBuffer += string
-                }
-            default: break
+        var data = frame.unmaskedData
+        switch type {
+        case .binary:
+            self.binaryBuffer.writeBuffer(&data)
+        case .text:
+            if let string = data.readString(length: data.readableBytes) {
+                self.textBuffer += string
             }
+        default: break
         }
     }
 }

--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -4,7 +4,7 @@ import NIOWebSocket
 extension WebSocket {
 
     /// Stores configuration for a WebSocket client/server instance
-    public struct Configuration: Sendable {
+    public struct Configuration {
         /// Defends against small payloads in frame aggregation.
         /// See `NIOWebSocketFrameAggregator` for details.
         public var minNonFinalFragmentSize: Int
@@ -35,7 +35,7 @@ extension WebSocket {
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
     public static func client(
         on channel: Channel,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .client, with: Configuration(), onUpgrade: onUpgrade)
     }
@@ -49,7 +49,7 @@ extension WebSocket {
     public static func client(
         on channel: Channel,
         config: Configuration,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .client, with: config, onUpgrade: onUpgrade)
     }
@@ -61,7 +61,7 @@ extension WebSocket {
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
     public static func server(
         on channel: Channel,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .server, with: Configuration(), onUpgrade: onUpgrade)
     }
@@ -75,7 +75,7 @@ extension WebSocket {
     public static func server(
         on channel: Channel,
         config: Configuration,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .server, with: config, onUpgrade: onUpgrade)
     }
@@ -84,7 +84,7 @@ extension WebSocket {
         on channel: Channel,
         as type: PeerType,
         with config: Configuration,
-        onUpgrade: @Sendable @escaping (WebSocket) -> ()
+        onUpgrade: @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         let webSocket = WebSocket(channel: channel, type: type)
 

--- a/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
@@ -5,12 +5,6 @@ import NIOWebSocket
 @testable import WebSocketKit
 
 final class AsyncWebSocketKitTests: XCTestCase {
-
-    override func setUp() async throws {
-        // Handy for catching hangs in the tests. See https://github.com/apple/swift-corelibs-xctest/issues/422#issuecomment-1310952437
-        fflush(stdout)
-    }
-
     func testWebSocketEcho() async throws {
         let server = try await ServerBootstrap.webSocket(on: self.elg) { req, ws in
             ws.onText { ws, text in
@@ -27,15 +21,15 @@ final class AsyncWebSocketKitTests: XCTestCase {
 
         try await WebSocket.connect(to: "ws://localhost:\(port)", on: elg) { ws in
             do {
+                try await ws.send("hello")
                 ws.onText { ws, string in
+                    promise.succeed(string)
                     do {
                         try await ws.close()
                     } catch {
                         XCTFail("Failed to close websocket, error: \(error)")
                     }
-                    promise.succeed(string)
                 }
-                try await ws.send("hello")
             } catch {
                 promise.fail(error)
             }
@@ -43,6 +37,23 @@ final class AsyncWebSocketKitTests: XCTestCase {
 
         let result = try await promise.futureResult.get()
         XCTAssertEqual(result, "hello")
+        try await server.close(mode: .all)
+    }
+
+    func testAlternateWebsocketConnectMethods() async throws {
+        let server = try await ServerBootstrap.webSocket(on: self.elg) { $1.onText { $0.send($1) } }.bind(host: "localhost", port: 0).get()
+        let promise = self.elg.any().makePromise(of: Void.self)
+        guard let port = server.localAddress?.port else {
+            return XCTFail("couldn't get port from \(String(reflecting: server.localAddress))")
+        }
+        try await WebSocket.connect(scheme: "ws", host: "localhost", port: port, on: self.elg) { (ws) async in
+            do { try await ws.send("hello") } catch { promise.fail(error); try? await ws.close() }
+            ws.onText { ws, _ in
+                promise.succeed(())
+                do { try await ws.close() } catch { XCTFail("Failed to close websocket: \(String(reflecting: error))") }
+            }
+        }
+        try await promise.futureResult.get()
         try await server.close(mode: .all)
     }
     
@@ -66,17 +77,11 @@ final class AsyncWebSocketKitTests: XCTestCase {
             return XCTFail("couldn't get port from \(String(reflecting: server.localAddress))")
         }
         try await WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { ws in
+            do { try await ws.send([0x01]) } catch { promise.fail(error); try? await ws.close() }
             ws.onBinary { ws, buf in
+                promise.succeed(.init(buf.readableBytesView))
                 do { try await ws.close() }
                 catch { XCTFail("Failed to close websocket: \(String(reflecting: error))") }
-                promise.succeed(.init(buf.readableBytesView))
-            }
-
-            do {
-                try await ws.send([0x01])
-            } catch {
-                try? await ws.close()
-                promise.fail(error);
             }
         }
         let result = try await promise.futureResult.get()
@@ -91,19 +96,10 @@ final class AsyncWebSocketKitTests: XCTestCase {
             return XCTFail("couldn't get port from \(String(reflecting: server.localAddress))")
         }
         try await WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { (ws) async in
+            do { try await ws.sendPing() } catch { promise.fail(error); try? await ws.close() }
             ws.onPong {
-                do {
-                    try await $0.close()
-                } catch {
-                    XCTFail("Failed to close websocket: \(String(reflecting: error))")
-                }
                 promise.succeed(())
-            }
-            do {
-                try await ws.sendPing()
-            } catch {
-                try? await ws.close()
-                promise.fail(error)
+                do { try await $0.close() } catch { XCTFail("Failed to close websocket: \(String(reflecting: error))") }
             }
         }
         try await promise.futureResult.get()
@@ -119,8 +115,8 @@ final class AsyncWebSocketKitTests: XCTestCase {
         try await WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { (ws) async in
             ws.pingInterval = .milliseconds(100)
             ws.onPong {
-                do { try await $0.close() } catch { XCTFail("Failed to close websocket: \(String(reflecting: error))") }
                 promise.succeed(())
+                do { try await $0.close() } catch { XCTFail("Failed to close websocket: \(String(reflecting: error))") }
             }
         }
         try await promise.futureResult.get()

--- a/Tests/WebSocketKitTests/SSLTestHelpers.swift
+++ b/Tests/WebSocketKitTests/SSLTestHelpers.swift
@@ -18,7 +18,6 @@ import Foundation
 import NIOCore
 @testable import NIOSSL
 
-
 // This function generates a random number suitable for use in an X509
 // serial field. This needs to be a positive number less than 2^159
 // (such that it will fit into 20 ASN.1 bytes).


### PR DESCRIPTION
Due to unforeseen source compatibility breakage, this backs out the changes from release 2.10.0 for now.