### PR TITLE
Sendable Take 2

### DIFF
--- a/.api-breakage/allowlist-branch-sendable-take-2.txt
+++ b/.api-breakage/allowlist-branch-sendable-take-2.txt
@@ -1,0 +1,6 @@
+API breakage: func WebSocket.onText(_:) is now with @preconcurrency
+API breakage: func WebSocket.onBinary(_:) is now with @preconcurrency
+API breakage: func WebSocket.onPong(_:) is now with @preconcurrency
+API breakage: func WebSocket.onPing(_:) is now with @preconcurrency
+API breakage: func WebSocket.connect(to:headers:configuration:on:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocket.connect(scheme:host:port:path:query:headers:configuration:on:onUpgrade:) is now with @preconcurrency

--- a/.api-breakage/allowlist-branch-sendable-take-2.txt
+++ b/.api-breakage/allowlist-branch-sendable-take-2.txt
@@ -4,3 +4,11 @@ API breakage: func WebSocket.onPong(_:) is now with @preconcurrency
 API breakage: func WebSocket.onPing(_:) is now with @preconcurrency
 API breakage: func WebSocket.connect(to:headers:configuration:on:onUpgrade:) is now with @preconcurrency
 API breakage: func WebSocket.connect(scheme:host:port:path:query:headers:configuration:on:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocket.connect(scheme:host:port:path:query:headers:proxy:proxyPort:proxyHeaders:proxyConnectDeadline:configuration:on:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocket.connect(to:headers:proxy:proxyPort:proxyHeaders:proxyConnectDeadline:configuration:on:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocket.client(on:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocket.client(on:config:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocket.server(on:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocket.server(on:config:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocketClient.connect(scheme:host:port:path:query:headers:onUpgrade:) is now with @preconcurrency
+API breakage: func WebSocketClient.connect(scheme:host:port:path:query:headers:proxy:proxyPort:proxyHeaders:proxyConnectDeadline:onUpgrade:) is now with @preconcurrency

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,9 +5,7 @@ concurrency:
 on:
   pull_request: { types: [opened, reopened, synchronize, ready_for_review] }
   push: { branches: [ main ] }
-
 jobs:
-
   vapor-integration:
     if: ${{ !(github.event.pull_request.draft || false) }}
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 DerivedData
 .swiftpm
 Package.resolved
+.devcontainer/

--- a/Package.swift
+++ b/Package.swift
@@ -16,8 +16,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.53.0"),
         .package(url: "https://github.com/apple/swift-nio-extras.git", from: "1.16.0"),
         .package(url: "https://github.com/apple/swift-nio-ssl.git", from: "2.24.0"),
-        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.11.4"),
-        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.0.2"),
+        .package(url: "https://github.com/apple/swift-nio-transport-services.git", from: "1.16.0"),
+        .package(url: "https://github.com/apple/swift-atomics.git", from: "1.1.0"),
     ],
     targets: [
         .target(name: "WebSocketKit", dependencies: [

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -40,7 +40,7 @@ extension WebSocket {
         try await close(code: code).get()
     }
 
-    public func onText(_ callback: @Sendable @escaping (WebSocket, String) async -> ()) {
+    @preconcurrency public func onText(_ callback: @Sendable @escaping (WebSocket, String) async -> ()) {
         self.eventLoop.execute {
             self.onText { socket, text in
                 Task {
@@ -50,7 +50,7 @@ extension WebSocket {
         }
     }
 
-    public func onBinary(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
+    @preconcurrency public func onBinary(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
         self.eventLoop.execute {
             self.onBinary { socket, binary in
                 Task {
@@ -60,7 +60,7 @@ extension WebSocket {
         }
     }
 
-    public func onPong(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
         self.eventLoop.execute {
             self.onPong { socket in
                 Task {
@@ -70,7 +70,7 @@ extension WebSocket {
         }
     }
 
-    public func onPing(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
         self.eventLoop.execute {
             self.onPing { socket in
                 Task {
@@ -80,7 +80,7 @@ extension WebSocket {
         }
     }
 
-    public static func connect(
+    @preconcurrency public static func connect(
         to url: String,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
@@ -100,7 +100,7 @@ extension WebSocket {
         ).get()
     }
 
-    public static func connect(
+    @preconcurrency public static func connect(
         to url: URL,
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
@@ -120,7 +120,7 @@ extension WebSocket {
         ).get()
     }
 
-    public static func connect(
+    @preconcurrency public static func connect(
         scheme: String = "ws",
         host: String,
         port: Int = 80,

--- a/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
+++ b/Sources/WebSocketKit/Concurrency/WebSocket+Concurrency.swift
@@ -40,34 +40,42 @@ extension WebSocket {
         try await close(code: code).get()
     }
 
-    public func onText(_ callback: @escaping (WebSocket, String) async -> ()) {
-        onText { socket, text in
-            Task {
-                await callback(socket, text)
+    public func onText(_ callback: @Sendable @escaping (WebSocket, String) async -> ()) {
+        self.eventLoop.execute {
+            self.onText { socket, text in
+                Task {
+                    await callback(socket, text)
+                }
             }
         }
     }
 
-    public func onBinary(_ callback: @escaping (WebSocket, ByteBuffer) async -> ()) {
-        onBinary { socket, binary in
-            Task {
-                await callback(socket, binary)
+    public func onBinary(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) async -> ()) {
+        self.eventLoop.execute {
+            self.onBinary { socket, binary in
+                Task {
+                    await callback(socket, binary)
+                }
             }
         }
     }
 
-    public func onPong(_ callback: @escaping (WebSocket) async -> ()) {
-        onPong { socket in
-            Task {
-                await callback(socket)
+    public func onPong(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+        self.eventLoop.execute {
+            self.onPong { socket in
+                Task {
+                    await callback(socket)
+                }
             }
         }
     }
 
-    public func onPing(_ callback: @escaping (WebSocket) async -> ()) {
-        onPing { socket in
-            Task {
-                await callback(socket)
+    public func onPing(_ callback: @Sendable @escaping (WebSocket) async -> ()) {
+        self.eventLoop.execute {
+            self.onPing { socket in
+                Task {
+                    await callback(socket)
+                }
             }
         }
     }
@@ -77,7 +85,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) async -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) async -> ()
     ) async throws {
         return try await self.connect(
             to: url,
@@ -97,7 +105,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) async -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) async -> ()
     ) async throws {
         return try await self.connect(
             to: url,
@@ -121,7 +129,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) async -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) async -> ()
     ) async throws {
         return try await self.connect(
             scheme: scheme,

--- a/Sources/WebSocketKit/Exports.swift
+++ b/Sources/WebSocketKit/Exports.swift
@@ -6,9 +6,7 @@
 @_documentation(visibility: internal) @_exported import protocol NIOCore.EventLoopGroup
 @_documentation(visibility: internal) @_exported import struct NIOCore.EventLoopPromise
 @_documentation(visibility: internal) @_exported import class NIOCore.EventLoopFuture
-
 @_documentation(visibility: internal) @_exported import struct NIOHTTP1.HTTPHeaders
-
 @_documentation(visibility: internal) @_exported import struct Foundation.URL
 
 #else
@@ -19,9 +17,7 @@
 @_exported import protocol NIOCore.EventLoopGroup
 @_exported import struct NIOCore.EventLoopPromise
 @_exported import class NIOCore.EventLoopFuture
-
 @_exported import struct NIOHTTP1.HTTPHeaders
-
 @_exported import struct Foundation.URL
 
 #endif

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -12,6 +12,7 @@ extension WebSocket {
     ///   - eventLoopGroup: Event loop group to be used by the WebSocket client.
     ///   - onUpgrade: An escaping closure to be executed after the upgrade is completed by `NIOWebSocketClientUpgrader`.
     /// - Returns: An future which completes when the connection to the WebSocket server is established.
+    @preconcurrency
     public static func connect(
         to url: String,
         headers: HTTPHeaders = [:],
@@ -40,6 +41,7 @@ extension WebSocket {
     ///   - eventLoopGroup: Event loop group to be used by the WebSocket client.
     ///   - onUpgrade: An escaping closure to be executed after the upgrade is completed by `NIOWebSocketClientUpgrader`.
     /// - Returns: An future which completes when the connection to the WebSocket server is established.
+    @preconcurrency
     public static func connect(
         to url: URL,
         headers: HTTPHeaders = [:],
@@ -74,6 +76,7 @@ extension WebSocket {
     ///   - eventLoopGroup: Event loop group to be used by the WebSocket client.
     ///   - onUpgrade: An escaping closure to be executed after the upgrade is completed by `NIOWebSocketClientUpgrader`.
     /// - Returns: An future which completes when the connection to the WebSocket server is established.
+    @preconcurrency
     public static func connect(
         scheme: String = "ws",
         host: String,
@@ -116,6 +119,7 @@ extension WebSocket {
     ///   - eventLoopGroup: Event loop group to be used by the WebSocket client.
     ///   - onUpgrade: An escaping closure to be executed after the upgrade is completed by `NIOWebSocketClientUpgrader`.
     /// - Returns: An future which completes when the connection to the origin server is established.
+    @preconcurrency
     public static func connect(
         scheme: String = "ws",
         host: String,
@@ -162,6 +166,7 @@ extension WebSocket {
     ///   - eventLoopGroup: Event loop group to be used by the WebSocket client.
     ///   - onUpgrade: An escaping closure to be executed after the upgrade is completed by `NIOWebSocketClientUpgrader`.
     /// - Returns: An future which completes when the connection to the origin server is established.
+    @preconcurrency
     public static func connect(
         to url: String,
         headers: HTTPHeaders = [:],

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -17,7 +17,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         guard let url = URL(string: url) else {
             return eventLoopGroup.any().makeFailedFuture(WebSocketClient.Error.invalidURL)
@@ -45,7 +45,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         let scheme = url.scheme ?? "ws"
         return self.connect(
@@ -83,7 +83,7 @@ extension WebSocket {
         headers: HTTPHeaders = [:],
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return WebSocketClient(
             eventLoopGroupProvider: .shared(eventLoopGroup),
@@ -129,7 +129,7 @@ extension WebSocket {
         proxyConnectDeadline: NIODeadline = NIODeadline.distantFuture,
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return WebSocketClient(
             eventLoopGroupProvider: .shared(eventLoopGroup),
@@ -171,7 +171,7 @@ extension WebSocket {
         proxyConnectDeadline: NIODeadline = NIODeadline.distantFuture,
         configuration: WebSocketClient.Configuration = .init(),
         on eventLoopGroup: EventLoopGroup,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         guard let url = URL(string: url) else {
             return eventLoopGroup.any().makeFailedFuture(WebSocketClient.Error.invalidURL)

--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -58,19 +58,19 @@ public final class WebSocket: Sendable {
         self._pingInterval = .init(nil)
     }
 
-    public func onText(_ callback: @Sendable @escaping (WebSocket, String) -> ()) {
+    @preconcurrency public func onText(_ callback: @Sendable @escaping (WebSocket, String) -> ()) {
         self.onTextCallback.value = callback
     }
 
-    public func onBinary(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
+    @preconcurrency public func onBinary(_ callback: @Sendable @escaping (WebSocket, ByteBuffer) -> ()) {
         self.onBinaryCallback.value = callback
     }
     
-    public func onPong(_ callback: @Sendable @escaping (WebSocket) -> ()) {
+    @preconcurrency public func onPong(_ callback: @Sendable @escaping (WebSocket) -> ()) {
         self.onPongCallback.value = callback
     }
 
-    public func onPing(_ callback: @Sendable @escaping (WebSocket) -> ()) {
+    @preconcurrency public func onPing(_ callback: @Sendable @escaping (WebSocket) -> ()) {
         self.onPingCallback.value = callback
     }
 

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -63,6 +63,7 @@ public final class WebSocketClient: Sendable {
         self.configuration = configuration
     }
 
+    @preconcurrency
     public func connect(
         scheme: String,
         host: String,
@@ -90,6 +91,7 @@ public final class WebSocketClient: Sendable {
     ///   - proxyConnectDeadline: Deadline for establishing the proxy connection.
     ///   - onUpgrade: An escaping closure to be executed after the upgrade is completed by `NIOWebSocketClientUpgrader`.
     /// - Returns: An future which completes when the connection to the origin server is established.
+    @preconcurrency
     public func connect(
         scheme: String,
         host: String,

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -9,7 +9,7 @@ import NIOSSL
 import NIOTransportServices
 import Atomics
 
-public final class WebSocketClient {
+public final class WebSocketClient: Sendable {
     public enum Error: Swift.Error, LocalizedError {
         case invalidURL
         case invalidResponseStatus(HTTPResponseHead)
@@ -21,7 +21,7 @@ public final class WebSocketClient {
 
     public typealias EventLoopGroupProvider = NIOEventLoopGroupProvider
 
-    public struct Configuration {
+    public struct Configuration: Sendable {
         public var tlsConfiguration: TLSConfiguration?
         public var maxFrameSize: Int
 
@@ -70,7 +70,7 @@ public final class WebSocketClient {
         path: String = "/",
         query: String? = nil,
         headers: HTTPHeaders = [:],
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         self.connect(scheme: scheme, host: host, port: port, path: path, query: query, headers: headers, proxy: nil, onUpgrade: onUpgrade)
     }
@@ -101,7 +101,7 @@ public final class WebSocketClient {
         proxyPort: Int? = nil,
         proxyHeaders: HTTPHeaders = [:],
         proxyConnectDeadline: NIODeadline = NIODeadline.distantFuture,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         assert(["ws", "wss"].contains(scheme))
         let upgradePromise = self.group.any().makePromise(of: Void.self)
@@ -130,6 +130,7 @@ public final class WebSocketClient {
                     headers: upgradeRequestHeaders,
                     upgradePromise: upgradePromise
                 )
+                let httpUpgradeRequestHandlerBox = NIOLoopBound(httpUpgradeRequestHandler, eventLoop: channel.eventLoop)
 
                 let websocketUpgrader = NIOWebSocketClientUpgrader(
                     maxFrameSize: self.configuration.maxFrameSize,
@@ -143,9 +144,10 @@ public final class WebSocketClient {
                     upgraders: [websocketUpgrader],
                     completionHandler: { context in
                         upgradePromise.succeed(())
-                        channel.pipeline.removeHandler(httpUpgradeRequestHandler, promise: nil)
+                        channel.pipeline.removeHandler(httpUpgradeRequestHandlerBox.value, promise: nil)
                     }
                 )
+                let configBox = NIOLoopBound(config, eventLoop: channel.eventLoop)
 
                 if proxy == nil || scheme == "ws" {
                     if scheme == "wss" {
@@ -163,15 +165,15 @@ public final class WebSocketClient {
                         leftOverBytesStrategy: .forwardBytes,
                         withClientUpgrade: config
                     ).flatMap {
-                        channel.pipeline.addHandler(httpUpgradeRequestHandler)
+                        channel.pipeline.addHandler(httpUpgradeRequestHandlerBox.value)
                     }
                 }
 
                 // TLS + proxy
                 // we need to handle connecting with an additional CONNECT request
                 let proxyEstablishedPromise = channel.eventLoop.makePromise(of: Void.self)
-                let encoder = HTTPRequestEncoder()
-                let decoder = ByteToMessageHandler(HTTPResponseDecoder(leftOverBytesStrategy: .dropBytes))
+                let encoder = NIOLoopBound(HTTPRequestEncoder(), eventLoop: channel.eventLoop)
+                let decoder = NIOLoopBound(ByteToMessageHandler(HTTPResponseDecoder(leftOverBytesStrategy: .dropBytes)), eventLoop: channel.eventLoop)
 
                 var connectHeaders = proxyHeaders
                 connectHeaders.add(name: "Host", value: host)
@@ -188,17 +190,17 @@ public final class WebSocketClient {
                 // They are then removed upon completion only to be re-added in `addHTTPClientHandlers`.
                 // This is done because the HTTP decoder is not valid after an upgrade, the CONNECT request being counted as one.
                 do {
-                    try channel.pipeline.syncOperations.addHandler(encoder)
-                    try channel.pipeline.syncOperations.addHandler(decoder)
+                    try channel.pipeline.syncOperations.addHandler(encoder.value)
+                    try channel.pipeline.syncOperations.addHandler(decoder.value)
                     try channel.pipeline.syncOperations.addHandler(proxyRequestHandler)
                 } catch {
                     return channel.eventLoop.makeFailedFuture(error)
                 }
 
                 proxyEstablishedPromise.futureResult.flatMap {
-                    channel.pipeline.removeHandler(decoder)
+                    channel.pipeline.removeHandler(decoder.value)
                 }.flatMap {
-                    channel.pipeline.removeHandler(encoder)
+                    channel.pipeline.removeHandler(encoder.value)
                 }.whenComplete { result in
                     switch result {
                     case .success:
@@ -209,9 +211,9 @@ public final class WebSocketClient {
                             try channel.pipeline.syncOperations.addHandler(tlsHandler)
                             try channel.pipeline.syncOperations.addHTTPClientHandlers(
                                 leftOverBytesStrategy: .forwardBytes,
-                                withClientUpgrade: config
+                                withClientUpgrade: configBox.value
                             )
-                            try channel.pipeline.syncOperations.addHandler(httpUpgradeRequestHandler)
+                            try channel.pipeline.syncOperations.addHandler(httpUpgradeRequestHandlerBox.value)
                         } catch {
                             channel.pipeline.close(mode: .all, promise: nil)
                         }
@@ -230,6 +232,7 @@ public final class WebSocketClient {
         }
     }
 
+    @Sendable
     private func makeTLSHandler(tlsConfiguration: TLSConfiguration?, host: String) throws -> NIOSSLClientHandler {
         let context = try NIOSSLContext(
             configuration: self.configuration.tlsConfiguration ?? .makeClientConfiguration()

--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -33,6 +33,7 @@ extension WebSocket {
     ///   - channel: NIO channel which the client will use to communicate.
     ///   - onUpgrade: An escaping closure to be executed the channel is configured with the WebSocket handlers.
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
+    @preconcurrency
     public static func client(
         on channel: Channel,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
@@ -46,6 +47,7 @@ extension WebSocket {
     ///   - config: Configuration for the client channel handlers.
     ///   - onUpgrade: An escaping closure to be executed the channel is configured with the WebSocket handlers.
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
+    @preconcurrency
     public static func client(
         on channel: Channel,
         config: Configuration,
@@ -59,6 +61,7 @@ extension WebSocket {
     ///   - channel: NIO channel which the server will use to communicate.
     ///   - onUpgrade: An escaping closure to be executed the channel is configured with the WebSocket handlers.
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
+    @preconcurrency
     public static func server(
         on channel: Channel,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
@@ -72,6 +75,7 @@ extension WebSocket {
     ///   - config: Configuration for the server channel handlers.
     ///   - onUpgrade: An escaping closure to be executed the channel is configured with the WebSocket handlers.
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
+    @preconcurrency
     public static func server(
         on channel: Channel,
         config: Configuration,

--- a/Sources/WebSocketKit/WebSocketHandler.swift
+++ b/Sources/WebSocketKit/WebSocketHandler.swift
@@ -4,7 +4,7 @@ import NIOWebSocket
 extension WebSocket {
 
     /// Stores configuration for a WebSocket client/server instance
-    public struct Configuration {
+    public struct Configuration: Sendable {
         /// Defends against small payloads in frame aggregation.
         /// See `NIOWebSocketFrameAggregator` for details.
         public var minNonFinalFragmentSize: Int
@@ -35,7 +35,7 @@ extension WebSocket {
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
     public static func client(
         on channel: Channel,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .client, with: Configuration(), onUpgrade: onUpgrade)
     }
@@ -49,7 +49,7 @@ extension WebSocket {
     public static func client(
         on channel: Channel,
         config: Configuration,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .client, with: config, onUpgrade: onUpgrade)
     }
@@ -61,7 +61,7 @@ extension WebSocket {
     /// - Returns: An future which completes when the WebSocket connection to the server is established.
     public static func server(
         on channel: Channel,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .server, with: Configuration(), onUpgrade: onUpgrade)
     }
@@ -75,7 +75,7 @@ extension WebSocket {
     public static func server(
         on channel: Channel,
         config: Configuration,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         return self.configure(on: channel, as: .server, with: config, onUpgrade: onUpgrade)
     }
@@ -84,7 +84,7 @@ extension WebSocket {
         on channel: Channel,
         as type: PeerType,
         with config: Configuration,
-        onUpgrade: @escaping (WebSocket) -> ()
+        onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         let webSocket = WebSocket(channel: channel, type: type)
 

--- a/Tests/WebSocketKitTests/SSLTestHelpers.swift
+++ b/Tests/WebSocketKitTests/SSLTestHelpers.swift
@@ -18,6 +18,7 @@ import Foundation
 import NIOCore
 @testable import NIOSSL
 
+
 // This function generates a random number suitable for use in an X509
 // serial field. This needs to be a positive number less than 2^159
 // (such that it will fit into 20 ASN.1 bytes).


### PR DESCRIPTION
Adds `Sendable` annotations where possible. This time we're using `@preconcurrency` to suppress errors in unsafe code from downstream users