### PR TITLE
Bump the swift-tools-version to 5.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.6
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(


### PR DESCRIPTION
Set the minimum supported Swift version to 5.7. This is due to the usage of `@preconcurrency`