### PR TITLE
Allow `send(_ binary:)` to accept `some DataProtocol`

### DIFF
--- a/Sources/WebSocketKit/WebSocket.swift
+++ b/Sources/WebSocketKit/WebSocket.swift
@@ -117,7 +117,7 @@ public final class WebSocket: Sendable {
 
     }
 
-    public func send(_ binary: [UInt8], promise: EventLoopPromise<Void>? = nil) {
+    public func send(_ binary: some DataProtocol, promise: EventLoopPromise<Void>? = nil) {
         self.send(raw: binary, opcode: .binary, fin: true, promise: promise)
     }
 


### PR DESCRIPTION
This allows for passing in `Data` or `ByteBufferView` to `send(_:)`, as well as the currently-supported `[UInt8]` type.
