### PR TITLE
Handle URL changes in latest Apple Platforms

### DIFF
--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -20,6 +20,7 @@ extension WebSocket {
         on eventLoopGroup: EventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
+        #if canImport(Foundation)
         let optionalURL: URL?
         if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             optionalURL = URL(string: url, encodingInvalidCharacters: false)
@@ -37,8 +38,20 @@ extension WebSocket {
             on: eventLoopGroup,
             onUpgrade: onUpgrade
         )
+        #else
+        guard let url = URL(string: url) else {
+            return eventLoopGroup.any().makeFailedFuture(WebSocketClient.Error.invalidURL)
+        }
+        return self.connect(
+            to: url,
+            headers: headers,
+            configuration: configuration,
+            on: eventLoopGroup,
+            onUpgrade: onUpgrade
+        )
+        #endif
     }
-
+    
     /// Establish a WebSocket connection.
     ///
     /// - Parameters:
@@ -69,7 +82,7 @@ extension WebSocket {
             onUpgrade: onUpgrade
         )
     }
-
+    
     /// Establish a WebSocket connection.
     ///
     /// - Parameters:
@@ -108,7 +121,7 @@ extension WebSocket {
             onUpgrade: onUpgrade
         )
     }
-
+    
     /// Establish a WebSocket connection via a proxy server.
     ///
     /// - Parameters:
@@ -159,8 +172,8 @@ extension WebSocket {
             onUpgrade: onUpgrade
         )
     }
-
-
+    
+    
     /// Description
     /// - Parameters:
     ///   - url: URL for the origin server.

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -20,9 +20,9 @@ extension WebSocket {
         on eventLoopGroup: EventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
-        #if canImport(Foundation)
+        #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
         let optionalURL: URL?
-        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
+        if #available(iOS 17.0, macOS 14.4, tvOS 17.0, watchOS 10.0, *) {
             optionalURL = URL(string: url, encodingInvalidCharacters: false)
         } else {
             optionalURL = URL(string: url)

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -22,7 +22,7 @@ extension WebSocket {
     ) -> EventLoopFuture<Void> {
         #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
         let optionalURL: URL?
-        if #available(iOS 17.0, macOS 14.3, tvOS 17.0, watchOS 10.0, *) {
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             optionalURL = URL(string: url, encodingInvalidCharacters: false)
         } else {
             optionalURL = URL(string: url)

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -22,7 +22,7 @@ extension WebSocket {
     ) -> EventLoopFuture<Void> {
         #if os(iOS) || os(tvOS) || os(watchOS) || os(macOS)
         let optionalURL: URL?
-        if #available(iOS 17.0, macOS 14.4, tvOS 17.0, watchOS 10.0, *) {
+        if #available(iOS 17.0, macOS 14.3, tvOS 17.0, watchOS 10.0, *) {
             optionalURL = URL(string: url, encodingInvalidCharacters: false)
         } else {
             optionalURL = URL(string: url)

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -21,7 +21,7 @@ extension WebSocket {
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
         let optionalURL: URL?
-        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *) {
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, *) {
             optionalURL = URL(string: url, encodingInvalidCharacters: false)
         } else {
             optionalURL = URL(string: url)

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -20,7 +20,10 @@ extension WebSocket {
         on eventLoopGroup: EventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
-        guard let url = URL(string: url) else {
+        guard
+            url.hasPrefix("ws://") || url.hasPrefix("wss://"),
+            let url = URL(string: url)
+        else {
             return eventLoopGroup.any().makeFailedFuture(WebSocketClient.Error.invalidURL)
         }
         return self.connect(

--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -20,12 +20,16 @@ extension WebSocket {
         on eventLoopGroup: EventLoopGroup,
         onUpgrade: @Sendable @escaping (WebSocket) -> ()
     ) -> EventLoopFuture<Void> {
-        guard
-            url.hasPrefix("ws://") || url.hasPrefix("wss://"),
-            let url = URL(string: url)
-        else {
+        let optionalURL: URL?
+        if #available(iOS 17.0, macOS 14.0, tvOS 17.0, watchOS 10.0, visionOS 1.0, *) {
+            optionalURL = URL(string: url, encodingInvalidCharacters: false)
+        } else {
+            optionalURL = URL(string: url)
+        }
+        guard let url = optionalURL else {
             return eventLoopGroup.any().makeFailedFuture(WebSocketClient.Error.invalidURL)
         }
+        
         return self.connect(
             to: url,
             headers: headers,

--- a/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/AsyncWebSocketKitTests.swift
@@ -91,9 +91,9 @@ final class AsyncWebSocketKitTests: XCTestCase {
             return XCTFail("couldn't get port from \(String(reflecting: server.localAddress))")
         }
         try await WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { (ws) async in
-            ws.onPong {
+            ws.onPong { webSocket, _ in
                 do {
-                    try await $0.close()
+                    try await webSocket.close()
                 } catch {
                     XCTFail("Failed to close websocket: \(String(reflecting: error))")
                 }
@@ -118,8 +118,8 @@ final class AsyncWebSocketKitTests: XCTestCase {
         }
         try await WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { (ws) async in
             ws.pingInterval = .milliseconds(100)
-            ws.onPong {
-                do { try await $0.close() } catch { XCTFail("Failed to close websocket: \(String(reflecting: error))") }
+            ws.onPong { webSocket, _ in
+                do { try await webSocket.close() } catch { XCTFail("Failed to close websocket: \(String(reflecting: error))") }
                 promise.succeed(())
             }
         }

--- a/Tests/WebSocketKitTests/SSLTestHelpers.swift
+++ b/Tests/WebSocketKitTests/SSLTestHelpers.swift
@@ -76,7 +76,7 @@ func generateRSAPrivateKey() -> OpaquePointer {
     precondition(generateRC == 1)
 
     let pkey = CNIOBoringSSL_EVP_PKEY_new()!
-    let assignRC = CNIOBoringSSL_EVP_PKEY_assign(pkey, EVP_PKEY_RSA, rsa)
+    let assignRC = CNIOBoringSSL_EVP_PKEY_assign_RSA(pkey, rsa)
     
     precondition(assignRC == 1)
     return pkey
@@ -125,7 +125,7 @@ func generateSelfSignedCert(keygenFunction: () -> OpaquePointer = generateRSAPri
                                                      NID_commonName,
                                                      MBSTRING_UTF8,
                                                      UnsafeMutablePointer(mutating: pointer),
-                                                     CInt(commonName.lengthOfBytes(using: .utf8)),
+                                                     ossl_ssize_t(commonName.lengthOfBytes(using: .utf8)),
                                                      -1,
                                                      0)
         }

--- a/Tests/WebSocketKitTests/WebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/WebSocketKitTests.swift
@@ -478,7 +478,7 @@ final class WebSocketKitTests: XCTestCase {
         try server.close(mode: .all).wait()
     }
     
-    func testBadURLInWebsocketConnect() async throws {
+    func testBadURLInWebsocketConnect() throws {
         XCTAssertThrowsError(try WebSocket.connect(to: "%w", on: self.elg, onUpgrade: { _ in }).wait()) {
             guard case .invalidURL = $0 as? WebSocketClient.Error else {
                 return XCTFail("Expected .invalidURL but got \(String(reflecting: $0))")

--- a/Tests/WebSocketKitTests/WebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/WebSocketKitTests.swift
@@ -516,8 +516,8 @@ final class WebSocketKitTests: XCTestCase {
             return XCTFail("couldn't get port from \(String(reflecting: server.localAddress))")
         }
         WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { ws in
-            ws.onPong {
-                $0.close(promise: closePromise)
+            ws.onPong { webSocket, _ in
+                webSocket.close(promise: closePromise)
                 promise.succeed()
             }
             ws.sendPing()
@@ -536,8 +536,8 @@ final class WebSocketKitTests: XCTestCase {
         }
         WebSocket.connect(to: "ws://localhost:\(port)", on: self.elg) { ws in
             ws.pingInterval = .milliseconds(100)
-            ws.onPong {
-                $0.close(promise: closePromise)
+            ws.onPong { webSocket, _ in
+                webSocket.close(promise: closePromise)
                 promise.succeed()
             }
         }.cascadeFailure(to: closePromise)


### PR DESCRIPTION
The latest Apple platforms automatically escape invalid URL characters - https://developer.apple.com/documentation/foundation/url/3126806-init

This aligns the behaviour across platform versions and Linux. Also updates a number of warnings in the tests
