### PR TITLE
Fix URI and configuration when using proxy

### DIFF
--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -193,6 +193,7 @@ extension WebSocket {
             proxyPort: proxyPort,
             proxyHeaders: proxyHeaders,
             proxyConnectDeadline: proxyConnectDeadline,
+            configuration: configuration,
             on: eventLoopGroup,
             onUpgrade: onUpgrade
         )

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -117,8 +117,7 @@ public final class WebSocketClient: Sendable {
                     uri = path
                 } else {
                     let relativePath = path.hasPrefix("/") ? path : "/" + path
-                    let port = proxyPort.map { ":\($0)" } ?? ""
-                    uri = "\(scheme)://\(host)\(relativePath)\(port)"
+                    uri = "\(scheme)://\(host):\(port)\(relativePath)"
 
                     if scheme == "ws" {
                         upgradeRequestHeaders.add(contentsOf: proxyHeaders)


### PR DESCRIPTION
This fixes 2 bugs

1. #147 URI formatting is wrong when using proxy
2. Configuration, e.g. tlsConfiguration is not used when using proxy
