### PR TITLE
refactor: use static ChannelOptions instead of raw definitions

### DIFF
--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -108,7 +108,7 @@ public final class WebSocketClient: Sendable {
         assert(["ws", "wss"].contains(scheme))
         let upgradePromise = self.group.any().makePromise(of: Void.self)
         let bootstrap = WebSocketClient.makeBootstrap(on: self.group)
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(IPPROTO_TCP), TCP_NODELAY), value: 1)
+            .channelOption(.tcpOption(.tcp_nodelay), value: 1)
             .channelInitializer { channel -> EventLoopFuture<Void> in
 
                 let uri: String

--- a/Tests/WebSocketKitTests/Utilities.swift
+++ b/Tests/WebSocketKitTests/Utilities.swift
@@ -102,7 +102,7 @@ internal final class WebsocketBin {
         }
 
         self.serverChannel = try! ServerBootstrap(group: self.group)
-            .serverChannelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
+            .serverChannelOption(.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 do {
 


### PR DESCRIPTION
<!-- 🚀 Thank you for contributing! -->

<!-- Describe your changes clearly and use examples if possible. -->

Minor refactor to make better use of the Swift types exposed to set channel options.

<!-- When this PR is merged, the title and body will be -->
<!-- used to generate a release automatically. -->
