### PR TITLE
Fix WebSocket proxy URL construction and missing configuration parameter

### DIFF
--- a/Sources/WebSocketKit/WebSocket+Connect.swift
+++ b/Sources/WebSocketKit/WebSocket+Connect.swift
@@ -193,6 +193,7 @@ extension WebSocket {
             proxyPort: proxyPort,
             proxyHeaders: proxyHeaders,
             proxyConnectDeadline: proxyConnectDeadline,
+            configuration: configuration,
             on: eventLoopGroup,
             onUpgrade: onUpgrade
         )

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -116,7 +116,8 @@ public final class WebSocketClient: Sendable {
                     uri = path
                 } else {
                     let relativePath = path.hasPrefix("/") ? path : "/" + path
-                    // ws: use absolute-form for proxy; wss: use origin-form after CONNECT tunnel
+                    // ws: use absolute-form (full URI) for direct proxy connection;
+                    // wss: use origin-form (path only) after CONNECT tunnel is established per RFC 7230
                     if scheme == "ws" {
                         let port = proxyPort.map { ":\($0)" } ?? ""
                         uri = "\(scheme)://\(host)\(port)\(relativePath)"

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -116,11 +116,13 @@ public final class WebSocketClient: Sendable {
                     uri = path
                 } else {
                     let relativePath = path.hasPrefix("/") ? path : "/" + path
-                    let port = proxyPort.map { ":\($0)" } ?? ""
-                    uri = "\(scheme)://\(host)\(port)\(relativePath)"
-
+                    // ws: use absolute-form for proxy; wss: use origin-form after CONNECT tunnel
                     if scheme == "ws" {
+                        let port = proxyPort.map { ":\($0)" } ?? ""
+                        uri = "\(scheme)://\(host)\(port)\(relativePath)"
                         upgradeRequestHeaders.add(contentsOf: proxyHeaders)
+                    } else {
+                        uri = relativePath
                     }
                 }
 

--- a/Sources/WebSocketKit/WebSocketClient.swift
+++ b/Sources/WebSocketKit/WebSocketClient.swift
@@ -117,7 +117,7 @@ public final class WebSocketClient: Sendable {
                 } else {
                     let relativePath = path.hasPrefix("/") ? path : "/" + path
                     let port = proxyPort.map { ":\($0)" } ?? ""
-                    uri = "\(scheme)://\(host)\(relativePath)\(port)"
+                    uri = "\(scheme)://\(host)\(port)\(relativePath)"
 
                     if scheme == "ws" {
                         upgradeRequestHeaders.add(contentsOf: proxyHeaders)

--- a/Tests/WebSocketKitTests/WebSocketKitTests.swift
+++ b/Tests/WebSocketKitTests/WebSocketKitTests.swift
@@ -348,7 +348,7 @@ final class WebSocketKitTests: XCTestCase {
 
         let localWebsocketBin: WebsocketBin
         let verifyProxyHead = { @Sendable (ctx: ChannelHandlerContext, requestHead: HTTPRequestHead) in
-            XCTAssertEqual(requestHead.uri, "ws://apple.com/:\(ctx.localAddress!.port!)")
+            XCTAssertEqual(requestHead.uri, "ws://apple.com:\(ctx.localAddress!.port!)/")
             XCTAssertEqual(requestHead.headers.first(name: "Host"), "apple.com")
         }
         localWebsocketBin = WebsocketBin(


### PR DESCRIPTION
**These changes are now available in [2.16.2](https://github.com/vapor/websocket-kit/releases/tag/2.16.2)**


 ## Background

  I noticed issue #147 regarding the incorrect WebSocket proxy URL construction. I also saw a similar solution proposed
  in PR #149 by @GEverding, which correctly identified the root cause of the problem.

  However, PR #149 received a change request from @0xTim asking for tests to verify the proxy URI generation. Since that
   PR has not been updated, I have created this PR with the complete fix including the requested test modifications.

  ## Changes

  ### 1. Fix proxy URL construction order - Fixes #147
  - Changed URL format from `ws://host/path:port` to `ws://host:port/path`
  - Updated test assertion in `testProxy` to expect the correct URL format
  - Credit to @GEverding for identifying this issue in PR #149

  ### 2. Add missing configuration parameter
  - Pass `configuration` parameter when connecting through proxy
  - Ensures client configuration is properly forwarded to the underlying connection

  ### 3. Use correct URI form for wss + proxy connections
  - For `wss` with proxy: use origin-form (`/path`) after CONNECT tunnel per RFC 7230
  - For `ws` with proxy: continue using absolute-form (`ws://host:port/path`)
  - This fixes potential compatibility issues with strict HTTP/1.1 servers

  ## Tests

  - ✅ All existing tests pass (24 tests)
  - ✅ `testProxy` and `testProxyTLS` verify the fixes work correctly

  ## Note

  `testBadHost` test is skipped in test runs as it hangs indefinitely when attempting to connect to an invalid hostname.
   This is a pre-existing issue in the test suite, unrelated to these fixes.